### PR TITLE
Chore: Update the changelog when `npm version` is run

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
         "lint:fix": "eslint src --fix",
         "serve": "vite --mode=demo --host",
         "changelog": "auto-changelog --package --commit-limit 0",
-        "changelog:commit": "npm run changelog && git add -A && git commit -m 'Update CHANGELOG.md'",
-        "release:patch": "npm version patch && npm run changelog:commit",
-        "release:minor": "npm version minor && npm run changelog:commit",
-        "release:major": "npm version major && npm run changelog:commit'"
+        "version": "npm run changelog && git add CHANGELOG.md"
     },
     "main": "./dist/orion-design.umd.js",
     "module": "./dist/orion-design.mjs",


### PR DESCRIPTION
# Description
Currently we have several custom npm commands for creating releases. This is not ideal and also clutters our commit history (makes two commits for every release). I realized these are unnecessary after learning you can add to the `npm version` command by adding a `version` script. This means we can use the built in `npm version` command and have it automatically include the updated changelog in the version commit. 

This means we will no longer have multi commit releases like this
<img width="368" alt="image" src="https://user-images.githubusercontent.com/6200442/205959698-6a218eb7-7ce9-4fea-ac1e-8f7be4ad56e6.png">

But a single version commit like we had before. 