### PR TITLE
Chore: Fix the demo routes and clean up

### DIFF
--- a/demo/router/routeRecordsFlat.ts
+++ b/demo/router/routeRecordsFlat.ts
@@ -15,17 +15,21 @@ function flattenRouteRecords(records: RouteRecordRaw[]): RouteRecordsFlat {
 }
 
 function flattenRouteRecord(record: RouteRecordRaw): RouteRecordsFlat | undefined {
-  if (!record.children) {
-    const route = { name: record.name }
-
-    if (record.path.startsWith('/')) {
-      return undefined
-    }
-
-    return { [getRouteRecordKey(route)]: route }
+  if (record.name === 'home') {
+    return undefined
   }
 
-  return flattenRouteRecords(record.children)
+  if (record.children) {
+    return flattenRouteRecords(record.children)
+  }
+
+  const route = { name: record.name }
+
+  if (record.path.startsWith('/')) {
+    return undefined
+  }
+
+  return { [getRouteRecordKey(route)]: route }
 }
 
 function getRouteRecordKey(route: { name?: RouteRecordName | null }): string {

--- a/demo/sections/concurrency/ConcurrencyLimitDetails.vue
+++ b/demo/sections/concurrency/ConcurrencyLimitDetails.vue
@@ -1,7 +1,7 @@
 <template>
   <ComponentPage title="ConcurrencyLimitDetails">
     <ConcurrencyLimitDetails :concurrency-limit="concurrencyLimit" />
-  </componentpage>
+  </ComponentPage>
 </template>
 
 <script lang="ts" setup>

--- a/demo/sections/concurrency/ConcurrencyLimitsTable.vue
+++ b/demo/sections/concurrency/ConcurrencyLimitsTable.vue
@@ -1,7 +1,7 @@
 <template>
   <ComponentPage title="Concurrency Limit">
     <ConcurrencyLimitsTable />
-  </componentpage>
+  </ComponentPage>
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
# Description
There was an error in the demo because the workspace routes were being included in the context sidebar search
<img width="663" alt="image" src="https://user-images.githubusercontent.com/6200442/207657392-31d836b5-35e8-434c-8e0d-14346495d017.png">
