### PR TITLE
chore: permission string audit

### DIFF
--- a/src/services/can.ts
+++ b/src/services/can.ts
@@ -31,7 +31,6 @@ export const workspacePermissions = [
   'delete:worker_pool',
   'delete:workspace_bot_access',
   'delete:workspace_user_access',
-  'delete:workspace',
   'read:automation',
   'read:block',
   'read:concurrency_limit',


### PR DESCRIPTION
delete:workspace should be account permission