### PR TITLE
Feature: OTable

### DIFF
--- a/demo/sections/general/OTable.vue
+++ b/demo/sections/general/OTable.vue
@@ -9,6 +9,16 @@
     <template #no-select>
       <OTable :data="data" :columns="columns" hide-select-column disable-select />
     </template>
+
+    <template #custom-column>
+      <OTable :data="data" :columns="columns">
+        <template #status="{ row }">
+          <p-tag :class="getClassForStatus(row.status)">
+            {{ row.status }}
+          </p-tag>
+        </template>
+      </OTable>
+    </template>
   </ComponentPage>
 </template>
 
@@ -17,10 +27,12 @@
   import ComponentPage from '@/demo/components/ComponentPage.vue'
   import { DemoSection } from '@/demo/types/demoSection'
   import { mocker } from '@/services'
+  import { choice } from '@/utilities'
 
   const demos: DemoSection[] = [
     { title: 'Empty' },
-    { title: 'No Select' },
+    { title: 'No select' },
+    { title: 'Custom column' },
   ]
 
   const columns = [
@@ -32,13 +44,49 @@
       label: 'Email',
       property: 'email',
     },
+    {
+      label: 'Status',
+      property: 'status',
+    },
   ]
 
+  const statuses = ['active', 'inactive', 'offline'] as const
+
   const data = Array.from({ length: 10 }, () => {
+    const name = mocker.create('noun')
     return {
       id: mocker.create('id'),
-      name: mocker.create('noun'),
-      email: mocker.create('email'),
+      name: name,
+      email: `${name}@email.com`,
+      status: choice(statuses),
     }
   })
+
+  const getClassForStatus = (status: typeof statuses[number]): Record<string, boolean> => {
+    let backgroundClass = 'bg-stone-200'
+    let foregroundClass = 'text-stone-800'
+
+    switch (status) {
+      case 'active':
+        backgroundClass = 'bg-emerald-200'
+        foregroundClass = 'text-emerald-800'
+        break
+      case 'inactive':
+        backgroundClass = 'bg-amber-200'
+        foregroundClass = 'text-amber-800'
+        break
+      case 'offline':
+        backgroundClass = 'bg-slate-200'
+        foregroundClass = 'text-slate-800'
+        break
+
+      default:
+        break
+    }
+
+    return {
+      [backgroundClass]: true,
+      [foregroundClass]: true,
+    }
+  }
 </script>

--- a/demo/sections/general/OTable.vue
+++ b/demo/sections/general/OTable.vue
@@ -1,17 +1,17 @@
 <template>
   <ComponentPage title="OTable" :demos="demos">
-    <OTable :data="data" :columns="columns" />
+    <OTable v-model:search="search" :data="filteredData" :columns="columns" />
 
     <template #empty>
-      <OTable :data="[]" :columns="[]" />
+      <OTable v-model:search="search" :data="[]" :columns="[]" />
     </template>
 
     <template #no-select>
-      <OTable :data="data" :columns="columns" hide-select-column disable-select />
+      <OTable v-model:search="search" :data="filteredData" :columns="columns" hide-select-column disable-select />
     </template>
 
     <template #custom-column>
-      <OTable :data="data" :columns="columns">
+      <OTable v-model:search="search" :data="filteredData" :columns="columns">
         <template #status="{ row }">
           <p-tag :class="getClassForStatus(row.status)">
             {{ row.status }}
@@ -23,6 +23,7 @@
 </template>
 
 <script lang="ts" setup>
+  import { ref, computed } from 'vue'
   import { OTable } from '@/components'
   import ComponentPage from '@/demo/components/ComponentPage.vue'
   import { DemoSection } from '@/demo/types/demoSection'
@@ -50,6 +51,8 @@
     },
   ]
 
+  const search = ref<string>('')
+
   const statuses = ['active', 'inactive', 'offline'] as const
 
   const data = Array.from({ length: 10 }, () => {
@@ -60,6 +63,13 @@
       email: `${name}@email.com`,
       status: choice(statuses),
     }
+  })
+
+  const filteredData = computed(() => {
+    return data.filter((row) => {
+      const values = Object.values(row).join(' ').toLowerCase()
+      return values.includes(search.value.toLowerCase())
+    })
   })
 
   const getClassForStatus = (status: typeof statuses[number]): Record<string, boolean> => {

--- a/demo/sections/general/OTable.vue
+++ b/demo/sections/general/OTable.vue
@@ -1,0 +1,11 @@
+<template>
+  <ComponentPage title="OTable">
+    <OTable :data="[]" :columns="[]" />
+  </ComponentPage>
+</template>
+
+<script lang="ts" setup>
+  import { OTable } from '@/components'
+  import ComponentPage from '@/demo/components/ComponentPage.vue'
+  import { mocker } from '@/services'
+</script>

--- a/demo/sections/general/OTable.vue
+++ b/demo/sections/general/OTable.vue
@@ -1,11 +1,44 @@
 <template>
-  <ComponentPage title="OTable">
-    <OTable :data="[]" :columns="[]" />
+  <ComponentPage title="OTable" :demos="demos">
+    <OTable :data="data" :columns="columns" />
+
+    <template #empty>
+      <OTable :data="[]" :columns="[]" />
+    </template>
+
+    <template #no-select>
+      <OTable :data="data" :columns="columns" hide-select-column disable-select />
+    </template>
   </ComponentPage>
 </template>
 
 <script lang="ts" setup>
   import { OTable } from '@/components'
   import ComponentPage from '@/demo/components/ComponentPage.vue'
+  import { DemoSection } from '@/demo/types/demoSection'
   import { mocker } from '@/services'
+
+  const demos: DemoSection[] = [
+    { title: 'Empty' },
+    { title: 'No Select' },
+  ]
+
+  const columns = [
+    {
+      label: 'Name',
+      property: 'name',
+    },
+    {
+      label: 'Email',
+      property: 'email',
+    },
+  ]
+
+  const data = Array.from({ length: 10 }, () => {
+    return {
+      id: mocker.create('id'),
+      name: mocker.create('noun'),
+      email: mocker.create('email'),
+    }
+  })
 </script>

--- a/demo/sections/general/index.ts
+++ b/demo/sections/general/index.ts
@@ -1,11 +1,12 @@
 import { Section } from '@/demo/router/routeRecords'
 
 export const general: Section = {
-  CodeBanner: () => import ('./CodeBanner.vue'),
-  CodeSnippet: () => import ('./CodeSnippet.vue'),
-  CodeView: () => import ('./CodeView.vue'),
-  ColorModeSelect: () => import ('./ColorModeSelect.vue'),
-  ColorModeSelectOption: () => import ('./ColorModeSelectOption.vue'),
-  ConfirmDeleteModal: () => import ('./ConfirmDeleteModal.vue'),
-  CopyOverflowMenuItem: () => import ('./CopyOverflowMenuItem.vue'),
+  CodeBanner: () => import('./CodeBanner.vue'),
+  CodeSnippet: () => import('./CodeSnippet.vue'),
+  CodeView: () => import('./CodeView.vue'),
+  ColorModeSelect: () => import('./ColorModeSelect.vue'),
+  ColorModeSelectOption: () => import('./ColorModeSelectOption.vue'),
+  ConfirmDeleteModal: () => import('./ConfirmDeleteModal.vue'),
+  CopyOverflowMenuItem: () => import('./CopyOverflowMenuItem.vue'),
+  OTable: () => import('./OTable.vue'),
 }

--- a/src/components/OTable.vue
+++ b/src/components/OTable.vue
@@ -1,0 +1,222 @@
+<template>
+  <div class="o-table">
+    <div class="o-table__controls-header">
+      <slot name="controls-header">
+        <div class="o-table__controls-header__section o-table__controls-header__section-start">
+          <slot name="controls-header__start">
+            <slot name="controls-header__start-before" />
+
+            <slot name="controls-header__counts">
+              <ResultsCount v-if="_selectedRows.length === 0" :label="rowsCountLabel" :count="_data.length" />
+              <SelectedCount v-else :count="_selectedRows.length" />
+            </slot>
+
+            <slot name="controls-header__start-after" />
+          </slot>
+        </div>
+
+        <div class="o-table__controls-header__section o-table__controls-header__section-end">
+          <slot name="controls__header__end">
+            <slot name="controls-header__end-before" />
+
+
+            <template v-if="!hideSearch">
+              <slot name="controls-header__search">
+                <SearchInput v-model="search" :disabled="disableSearch" :placeholder="searchPlaceholder" :label="searchLabel" />
+              </slot>
+            </template>
+
+            <slot name="controls-header__end-after" />
+          </slot>
+        </div>
+      </slot>
+    </div>
+
+    <p-table v-bind="attrs" :data="_data" :columns="_columns">
+      <template #select-heading>
+        <p-checkbox v-model="select" :disabled="disableSelect" />
+      </template>
+
+      <template #actions-heading>
+        <span />
+      </template>
+
+      <template #select="{ row }">
+        <p-checkbox v-model="_selectedRows" :value="row" :disabled="disableSelect" />
+      </template>
+
+      <slot />
+
+      <template #actions="{ row }">
+        <div class="o-table__row__actions">
+          <slot name="actions" :row="row" />
+        </div>
+      </template>
+
+
+      <template #empty-state>
+        <p-empty-results>
+          <template #message>
+            No {{ emptyResultsLabel }}
+          </template>
+          <template #actions>
+            <p-button size="sm" secondary @click="clear">
+              Clear Filters
+            </p-button>
+          </template>
+        </p-empty-results>
+      </template>
+    </p-table>
+
+
+    <slot name="controls__footer">
+      <slot name="controls__footer__start" />
+      <slot name="controls__footer__end" />
+    </slot>
+  </div>
+</template>
+
+<script lang="ts">
+  export default {
+    name: 'OTable',
+    expose: [],
+    inheritAttrs: false,
+  }
+</script>
+
+<script lang="ts" setup>
+  import { TableColumn, TableData } from '@prefecthq/prefect-design'
+  import { ref, useAttrs, computed } from 'vue'
+  import { SearchInput, ResultsCount, SelectedCount } from '@/components'
+
+  export type TableDataFilter = (term: string, row: TableData, index: number, arr: TableData[]) => boolean
+
+  const attrs = useAttrs()
+
+  const props = withDefaults(defineProps<{
+    selectedRows?: TableData[],
+    columns: TableColumn[],
+    data: TableData[],
+    emptyResultsLabel?: string,
+    searchPlaceholder?: string,
+    searchLabel?: string,
+    rowsCountLabel?: string,
+    disableSelect?: boolean,
+    disableSearch?: boolean,
+    hideSearch?: boolean,
+    hideSelectColumn?: boolean,
+    hideActionsColumn?: boolean,
+    search?: TableDataFilter,
+  }>(), {
+    selectedRows: () => [],
+    emptyResultsLabel: 'results',
+    searchPlaceholder: 'Search',
+    searchLabel: 'Search',
+    rowsCountLabel: 'row',
+    search: (term: string, row: TableData) => {
+      const values = Object.values(row).join(' ').toLowerCase()
+      return values.includes(term.toLowerCase())
+    },
+  })
+
+  const emit = defineEmits<{
+    (event: 'update:selectedRows', value: TableData[]): void,
+  }>()
+
+  const search = ref<string>('')
+
+  const _selectedRows = computed({
+    get() {
+      return props.disableSelect ? [] : props.selectedRows
+    },
+    set(value: TableData[]) {
+      if (props.disableSelect) {
+        return
+      }
+
+      emit('update:selectedRows', value)
+    },
+  })
+
+  const select = computed({
+    get() {
+      return _selectedRows.value.length === props.data.length
+    },
+    set(value: boolean) {
+      handleRowSelectAll(value)
+    },
+  })
+
+  const handleRowSelectAll = (value: boolean): void => {
+    if (value) {
+      _selectedRows.value = props.data
+    } else {
+      _selectedRows.value = []
+    }
+  }
+
+  function clear(): void {
+    search.value = ''
+  }
+
+
+  const _columns = computed(() => {
+    return [
+      {
+        label: 'select',
+        width: '20px',
+        visible: !props.hideSelectColumn,
+      },
+      ...props.columns,
+      {
+        label: 'actions',
+        width: '42px',
+        visible: !props.hideActionsColumn,
+      },
+    ]
+  })
+
+  const _data = computed(() => {
+    if (!search.value) {
+      return props.data
+    }
+
+    return props.data.filter((row, index, arr) => props.search(search.value, row, index, arr))
+  })
+</script>
+
+<style>
+.o-table__controls-header { @apply
+  flex
+  justify-between
+  items-center
+  mb-2
+  sticky
+  top-0
+  bg-white
+  bg-opacity-90
+  py-2
+  z-10
+}
+
+.o-table__controls-header__section { @apply
+  flex
+  gap-2
+  items-center
+}
+
+.o-table__controls-header__section-start { @apply
+  mr-auto
+}
+
+.o-table__controls-header__section-end { @apply
+  ml-auto
+}
+
+.o-table__row__actions { @apply
+  justify-end
+  items-center
+  flex
+  gap-2
+}
+</style>

--- a/src/components/OTable.vue
+++ b/src/components/OTable.vue
@@ -104,7 +104,7 @@
   const attrs = useAttrs()
 
   const props = withDefaults(defineProps<{
-    search?: string,
+    search: string,
     selectedRows?: TableData[],
     columns: TableColumn[],
     data: TableData[],
@@ -116,7 +116,6 @@
     hideSelectColumn?: boolean,
     hideActionsColumn?: boolean,
   }>(), {
-    search: '',
     selectedRows: () => [],
     label: 'result',
     searchPlaceholder: 'Search',

--- a/src/components/OTable.vue
+++ b/src/components/OTable.vue
@@ -2,7 +2,7 @@
   <div class="o-table">
     <div class="o-table__controls-header">
       <slot name="controls-header">
-        <div class="o-table__controls-header__section o-table__controls-header__section-start">
+        <div class="o-table__controls__section o-table__controls__section-start">
           <slot name="controls-header__start">
             <slot name="controls-header__start-before" />
 
@@ -15,7 +15,7 @@
           </slot>
         </div>
 
-        <div class="o-table__controls-header__section o-table__controls-header__section-end">
+        <div class="o-table__controls__section o-table__controls__section-end">
           <slot name="controls__header__end">
             <slot name="controls-header__end-before" />
 
@@ -71,11 +71,17 @@
       </template>
     </p-table>
 
+    <div class="o-table__controls-footer">
+      <slot name="controls__footer">
+        <div class="o-table__controls__section o-table__controls__section-start">
+          <slot name="controls__footer__start" />
+        </div>
 
-    <slot name="controls__footer">
-      <slot name="controls__footer__start" />
-      <slot name="controls__footer__end" />
-    </slot>
+        <div class="o-table__controls__section o-table__controls__section-end">
+          <slot name="controls__footer__end" />
+        </div>
+      </slot>
+    </div>
   </div>
 </template>
 
@@ -205,17 +211,28 @@
   z-10
 }
 
-.o-table__controls-header__section { @apply
+.o-table__controls-footer { @apply
+  flex
+  justify-between
+  items-center
+  mt-2
+  bg-white
+  bg-opacity-90
+  py-2
+  z-10
+}
+
+.o-table__controls__section { @apply
   flex
   gap-2
   items-center
 }
 
-.o-table__controls-header__section-start { @apply
+.o-table__controls__section-start { @apply
   mr-auto
 }
 
-.o-table__controls-header__section-end { @apply
+.o-table__controls__section-end { @apply
   ml-auto
 }
 

--- a/src/components/OTable.vue
+++ b/src/components/OTable.vue
@@ -34,7 +34,8 @@
 
     <p-table v-bind="attrs" :data="_data" :columns="_columns">
       <template #select-heading>
-        <p-checkbox v-model="select" :disabled="disableSelect" />
+        <p-checkbox v-if="!noData" v-model="select" :disabled="disableSelect" />
+        <span v-else />
       </template>
 
       <template #actions-heading>
@@ -60,7 +61,7 @@
             No {{ emptyResultsLabel }}
           </template>
           <template #actions>
-            <p-button size="sm" secondary @click="clear">
+            <p-button v-if="!noData" size="sm" secondary @click="clear">
               Clear Filters
             </p-button>
           </template>
@@ -182,6 +183,10 @@
     }
 
     return props.data.filter((row, index, arr) => props.search(search.value, row, index, arr))
+  })
+
+  const noData = computed(() => {
+    return props.data.length === 0 && search.value === ''
   })
 </script>
 

--- a/src/components/OTable.vue
+++ b/src/components/OTable.vue
@@ -162,11 +162,6 @@
     search.value = ''
   }
 
-  // const filteredSlots = computed(() => {
-  //   const slots = Object.keys()
-  //   return slots.filter((slot) => !slot.startsWith('o-table'))
-  // })
-
   const _columns = computed(() => {
     return [
       {

--- a/src/components/OTable.vue
+++ b/src/components/OTable.vue
@@ -46,7 +46,9 @@
         <p-checkbox v-model="_selectedRows" :value="row" :disabled="disableSelect" />
       </template>
 
-      <slot />
+      <template v-for="(_, name) in $slots" #[name]="slotData">
+        <slot :name="name" v-bind="slotData" />
+      </template>
 
       <template #actions="{ row }">
         <div class="o-table__row__actions">
@@ -160,6 +162,10 @@
     search.value = ''
   }
 
+  // const filteredSlots = computed(() => {
+  //   const slots = Object.keys()
+  //   return slots.filter((slot) => !slot.startsWith('o-table'))
+  // })
 
   const _columns = computed(() => {
     return [

--- a/src/components/OTable.vue
+++ b/src/components/OTable.vue
@@ -2,22 +2,22 @@
   <div class="o-table">
     <div class="o-table__controls-header">
       <slot name="controls-header">
-        <div class="o-table__controls__section o-table__controls__section-start">
+        <div class="o-table__controls__section o-table__controls__section--start">
           <slot name="controls-header__start">
-            <slot name="controls-header__start-before" />
+            <slot name="controls-header__start--before" />
 
             <slot name="controls-header__counts">
               <ResultsCount v-if="internalSelectedRows.length === 0" :label="label" :count="data.length" />
               <SelectedCount v-else :count="internalSelectedRows.length" />
             </slot>
 
-            <slot name="controls-header__start-after" />
+            <slot name="controls-header__start--after" />
           </slot>
         </div>
 
-        <div class="o-table__controls__section o-table__controls__section-end">
-          <slot name="controls__header__end">
-            <slot name="controls-header__end-before" />
+        <div class="o-table__controls__section o-table__controls__section--end">
+          <slot name="controls-header__end">
+            <slot name="controls-header__end--before" />
 
 
             <template v-if="!hideSearch">
@@ -26,7 +26,7 @@
               </slot>
             </template>
 
-            <slot name="controls-header__end-after" />
+            <slot name="controls-header__end--after" />
           </slot>
         </div>
       </slot>
@@ -72,13 +72,13 @@
     </p-table>
 
     <div class="o-table__controls-footer">
-      <slot name="controls__footer">
-        <div class="o-table__controls__section o-table__controls__section-start">
-          <slot name="controls__footer__start" />
+      <slot name="controls-footer">
+        <div class="o-table__controls__section o-table__controls__section--start">
+          <slot name="controls-footer__start" />
         </div>
 
-        <div class="o-table__controls__section o-table__controls__section-end">
-          <slot name="controls__footer__end" />
+        <div class="o-table__controls__section o-table__controls__section--end">
+          <slot name="controls-footer__end" />
         </div>
       </slot>
     </div>
@@ -223,11 +223,11 @@
   items-center
 }
 
-.o-table__controls__section-start { @apply
+.o-table__controls__section--start { @apply
   mr-auto
 }
 
-.o-table__controls__section-end { @apply
+.o-table__controls__section--end { @apply
   ml-auto
 }
 

--- a/src/components/OTable.vue
+++ b/src/components/OTable.vue
@@ -7,8 +7,8 @@
             <slot name="controls-header__start-before" />
 
             <slot name="controls-header__counts">
-              <ResultsCount v-if="_selectedRows.length === 0" :label="rowsCountLabel" :count="_data.length" />
-              <SelectedCount v-else :count="_selectedRows.length" />
+              <ResultsCount v-if="internalSelectedRows.length === 0" :label="rowsCountLabel" :count="_data.length" />
+              <SelectedCount v-else :count="internalSelectedRows.length" />
             </slot>
 
             <slot name="controls-header__start-after" />
@@ -32,7 +32,7 @@
       </slot>
     </div>
 
-    <p-table v-bind="attrs" :data="_data" :columns="_columns">
+    <p-table v-bind="attrs" :data="_data" :columns="internalColumns">
       <template #select-heading>
         <p-checkbox v-if="!noData" v-model="select" :disabled="disableSelect" />
         <span v-else />
@@ -43,7 +43,7 @@
       </template>
 
       <template #select="{ row }">
-        <p-checkbox v-model="_selectedRows" :value="row" :disabled="disableSelect" />
+        <p-checkbox v-model="internalSelectedRows" :value="row" :disabled="disableSelect" />
       </template>
 
       <template v-for="(_, name) in $slots" #[name]="slotData">
@@ -134,7 +134,7 @@
 
   const search = ref<string>('')
 
-  const _selectedRows = computed({
+  const internalSelectedRows = computed({
     get() {
       return props.disableSelect ? [] : props.selectedRows
     },
@@ -149,7 +149,7 @@
 
   const select = computed({
     get() {
-      return _selectedRows.value.length === props.data.length
+      return internalSelectedRows.value.length === props.data.length
     },
     set(value: boolean) {
       handleRowSelectAll(value)
@@ -158,9 +158,9 @@
 
   const handleRowSelectAll = (value: boolean): void => {
     if (value) {
-      _selectedRows.value = props.data
+      internalSelectedRows.value = props.data
     } else {
-      _selectedRows.value = []
+      internalSelectedRows.value = []
     }
   }
 
@@ -168,7 +168,7 @@
     search.value = ''
   }
 
-  const _columns = computed(() => {
+  const internalColumns = computed(() => {
     return [
       {
         label: 'select',

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -111,6 +111,7 @@ export { default as NotificationsPageEmptyState } from './NotificationsPageEmpty
 export { default as NotificationsTable } from './NotificationsTable.vue'
 export { default as NotificationStatusSelect } from './NotificationStatusSelect.vue'
 export { default as NotificationToggle } from './NotificationToggle.vue'
+export { default as OTable } from './PageHeading.vue'
 export { default as PageHeading } from './PageHeading.vue'
 export { default as PageHeadingAccountSettings } from './PageHeadingAccountSettings.vue'
 export { default as PageHeadingApiKeys } from './PageHeadingApiKeys.vue'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -111,7 +111,7 @@ export { default as NotificationsPageEmptyState } from './NotificationsPageEmpty
 export { default as NotificationsTable } from './NotificationsTable.vue'
 export { default as NotificationStatusSelect } from './NotificationStatusSelect.vue'
 export { default as NotificationToggle } from './NotificationToggle.vue'
-export { default as OTable } from './PageHeading.vue'
+export { default as OTable } from './OTable.vue'
 export { default as PageHeading } from './PageHeading.vue'
 export { default as PageHeadingAccountSettings } from './PageHeadingAccountSettings.vue'
 export { default as PageHeadingApiKeys } from './PageHeadingApiKeys.vue'


### PR DESCRIPTION
This PR introduces a new table-wrapping component that incorporates some of the common patterns I've seen floating around the library. It should allow us to cut down on a ton of boilerplate when creating new tables.

The `OTable` component is used in almost the exact same ways as `PTable`, with the except that it requires column headers to be passed. All slots and styling is passed to the wrapped `PTable` component, and controls exist to extend, override, disable, and augment functionality of results, empty state, search, etc.

Note: the demo could use a little work, I only included some pretty basic use cases for the moment.

cc @marichka-offen 