### PR TITLE
Chore: Fix the umd bundle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,17 @@ import { ToastPlugin } from '@prefecthq/prefect-design'
 import { App, Plugin } from 'vue'
 import { clearOldCacheKeys } from '@/utilities/cache'
 
+// hacky safeguard for keeping window references from breaking the umd build
+// which is used for node and specifically integration tests in orion-ui
+// the specific window reference that's causing issues is in the pixi-viewport
+// package. But this should also safeguard us from other window references sneaking
+// into the umd bundle.
+if (typeof window === 'undefined') {
+  const window = {}
+
+  Object.assign(global, { window })
+}
+
 const plugin: Plugin = {
   install(app: App) {
     app.use(ToastPlugin)


### PR DESCRIPTION
# Description
The introduction of the pixi-viewport package introduces a `window` reference into the global scope of this package. This causes orion-design to be unusable in a node context. 

The integration tests in orion-ui use orion-design's mocks and apis for test fixtures in node. So this allows us to continue with integration tests without solving the underlying issue of isolation components from raw js code. 