### PR TITLE
Chore: Add data attribute to identify notifications in the dom by their id

### DIFF
--- a/src/components/NotificationsTable.vue
+++ b/src/components/NotificationsTable.vue
@@ -6,11 +6,11 @@
     </div>
 
     <p-table :data="filtered" :columns="columns" class="notifications-table">
-      <template #notification="{ row }">
-        <div class="notifications-table__details">
-          <BlockDocument v-slot="{ blockDocument }" :block-document-id="row.blockDocumentId">
+      <template #notification="{ row: notification }: { row: Notification }">
+        <div class="notifications-table__details" :data-notification-id="notification.id">
+          <BlockDocument v-slot="{ blockDocument }" :block-document-id="notification.blockDocumentId">
             <NotificationDetails
-              :notification="row"
+              :notification="notification"
               :block-type="blockDocument.blockType"
               :data="blockDocument.data"
             />


### PR DESCRIPTION
# Description
We need some way to identify individual notifications in the DOM in order to use text fixtures in the orion-ui integration tests. A simple yet effective way is to add the notification id as a data attribute. 