### PR TITLE
Feature: ready to support flags defined in orion-design

### DIFF
--- a/demo/App.vue
+++ b/demo/App.vue
@@ -24,7 +24,7 @@
   import ContextSidebar from '@/demo/components/ContextSidebar.vue'
   import { mobileMenuOpen, toggle } from '@/demo/router/menu'
   import { createWorkspaceRoutes, workspaceRoutesKey } from '@/router'
-  import { canKey, createCan, workspacePermissions } from '@/services/can'
+  import { canKey, createCan, workspacePermissions, featureFlags } from '@/services/can'
 
   const showMenu = computed(() => media.lg || mobileMenuOpen.value)
 
@@ -32,7 +32,10 @@
 
   useWorkspaceApiMock()
 
-  const can = createCan(workspacePermissions)
+  const can = createCan([
+    ...featureFlags,
+    ...workspacePermissions,
+  ])
   provide(canKey, can)
 
   const routes = createWorkspaceRoutes()

--- a/demo/App.vue
+++ b/demo/App.vue
@@ -24,7 +24,7 @@
   import ContextSidebar from '@/demo/components/ContextSidebar.vue'
   import { mobileMenuOpen, toggle } from '@/demo/router/menu'
   import { createWorkspaceRoutes, workspaceRoutesKey } from '@/router'
-  import { canKey, createCan, workspacePermissions, featureFlags } from '@/services/can'
+  import { canKey, createCan, workspacePermissions, workspaceFeatureFlags } from '@/services/can'
 
   const showMenu = computed(() => media.lg || mobileMenuOpen.value)
 
@@ -33,7 +33,7 @@
   useWorkspaceApiMock()
 
   const can = createCan([
-    ...featureFlags,
+    ...workspaceFeatureFlags,
     ...workspacePermissions,
   ])
   provide(canKey, can)

--- a/src/compositions/useCan.ts
+++ b/src/compositions/useCan.ts
@@ -1,6 +1,6 @@
-import { Can, WorkspacePermission, canKey } from '@/services/can'
+import { Can, WorkspacePermission, canKey, FeatureFlags } from '@/services/can'
 import { inject } from '@/utilities/inject'
 
-export function useCan(): Can<WorkspacePermission> {
+export function useCan(): Can<WorkspacePermission | FeatureFlags> {
   return inject(canKey)
 }

--- a/src/compositions/useCan.ts
+++ b/src/compositions/useCan.ts
@@ -1,6 +1,6 @@
-import { Can, WorkspacePermission, canKey, FeatureFlags } from '@/services/can'
+import { Can, WorkspacePermission, canKey, WorkspaceFeatureFlag } from '@/services/can'
 import { inject } from '@/utilities/inject'
 
-export function useCan(): Can<WorkspacePermission | FeatureFlags> {
+export function useCan(): Can<WorkspacePermission | WorkspaceFeatureFlag> {
   return inject(canKey)
 }

--- a/src/services/can.ts
+++ b/src/services/can.ts
@@ -1,8 +1,8 @@
 import { InjectionKey, ref } from 'vue'
 import { MaybeRef } from '@/types/reactivity'
 
-export const featureFlags = [] as const
-export type FeatureFlags = typeof featureFlags[number]
+export const workspaceFeatureFlags = [] as const
+export type WorkspaceFeatureFlag = typeof workspaceFeatureFlags[number]
 
 export const workspacePermissions = [
   'create:automation',
@@ -93,4 +93,4 @@ export function createCan<T extends string>(permissions: MaybeRef<Readonly<T[]>>
   })
 }
 
-export const canKey: InjectionKey<Can<WorkspacePermission | FeatureFlags>> = Symbol('canInjectionKey')
+export const canKey: InjectionKey<Can<WorkspacePermission | WorkspaceFeatureFlag>> = Symbol('canInjectionKey')

--- a/src/services/can.ts
+++ b/src/services/can.ts
@@ -1,6 +1,9 @@
 import { InjectionKey, ref } from 'vue'
 import { MaybeRef } from '@/types/reactivity'
 
+export const featureFlags = [] as const
+export type FeatureFlags = typeof featureFlags[number]
+
 export const workspacePermissions = [
   'create:automation',
   'create:block',
@@ -63,7 +66,6 @@ export const workspacePermissions = [
   'update:workspace_user_access',
   'update:workspace',
 ] as const
-
 export type WorkspacePermission = typeof workspacePermissions[number]
 
 export type PermissionValue = boolean | undefined
@@ -91,4 +93,4 @@ export function createCan<T extends string>(permissions: MaybeRef<Readonly<T[]>>
   })
 }
 
-export const canKey: InjectionKey<Can<WorkspacePermission>> = Symbol('canInjectionKey')
+export const canKey: InjectionKey<Can<WorkspacePermission | FeatureFlags>> = Symbol('canInjectionKey')


### PR DESCRIPTION
this puts down the framework to define flags in orion-design (as well as in nebula/orion-ui still).

flags can be defined in orion-design if they are planned to be implemented in both nebula and orion-ui

defining a can in nebula will be the combination of

- orion-design "WorkspacePermission"
- orion-design "FeatureFlags"
- nebula-ui "AccountPermission"
- nebula-ui "FeatureFlags"

defining a can in orion-ui will be the combination of 

- orion-design "WorkspacePermission"
- orion-design "FeatureFlags"
- orion-ui "FeatureFlags"