### PR TITLE
Chore: Fix dependency duplication 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
                 "@prefecthq/graphs": "0.1.8",
                 "@prefecthq/radar": "0.0.17",
                 "@prefecthq/vue-charts": "0.0.19",
-                "@prefecthq/vue-compositions": "1.1.3",
                 "axios": "0.27.2",
                 "cronstrue": "^2.21.0",
                 "date-fns": "2.29.3",
@@ -40,7 +39,8 @@
                 "vue-tsc": "1.0.19"
             },
             "peerDependencies": {
-                "@prefecthq/prefect-design": "^1.1.43",
+                "@prefecthq/prefect-design": "1.1.43",
+                "@prefecthq/vue-compositions": "1.1.3",
                 "vee-validate": "^4.5.11",
                 "vue": "^3.2.45",
                 "vue-router": "^4.0.12"
@@ -1056,6 +1056,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.1.3.tgz",
             "integrity": "sha512-9/7y7Gh8IydD1mSbUEaIv4I2/XzQeH/d5HZvIeEfdcARoQWnZSVOPVH1r3h7RH5UyuSeTeJUeevqPj3HxsRN8Q==",
+            "peer": true,
             "dependencies": {
                 "jsdom": "^20.0.3"
             },
@@ -1121,6 +1122,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
             "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -1609,7 +1611,8 @@
         "node_modules/abab": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-            "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
+            "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+            "peer": true
         },
         "node_modules/acorn": {
             "version": "8.8.1",
@@ -1626,6 +1629,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
             "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+            "peer": true,
             "dependencies": {
                 "acorn": "^8.1.0",
                 "acorn-walk": "^8.0.2"
@@ -1635,6 +1639,7 @@
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
             "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "peer": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -1681,6 +1686,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "peer": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -2183,12 +2189,14 @@
         "node_modules/cssom": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-            "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
+            "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+            "peer": true
         },
         "node_modules/cssstyle": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
             "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+            "peer": true,
             "dependencies": {
                 "cssom": "~0.3.6"
             },
@@ -2199,7 +2207,8 @@
         "node_modules/cssstyle/node_modules/cssom": {
             "version": "0.3.8",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+            "peer": true
         },
         "node_modules/csstype": {
             "version": "2.6.21",
@@ -2581,6 +2590,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
             "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+            "peer": true,
             "dependencies": {
                 "abab": "^2.0.6",
                 "whatwg-mimetype": "^3.0.0",
@@ -2594,6 +2604,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
             "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.1"
             },
@@ -2605,6 +2616,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -2613,6 +2625,7 @@
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
             "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+            "peer": true,
             "dependencies": {
                 "tr46": "^3.0.0",
                 "webidl-conversions": "^7.0.0"
@@ -2666,7 +2679,8 @@
         "node_modules/decimal.js": {
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+            "peer": true
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
@@ -2799,6 +2813,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
             "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+            "peer": true,
             "dependencies": {
                 "webidl-conversions": "^7.0.0"
             },
@@ -2810,6 +2825,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -3005,6 +3021,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
             "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+            "peer": true,
             "dependencies": {
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
@@ -3026,6 +3043,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -3034,6 +3052,7 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
             "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
@@ -3046,6 +3065,7 @@
             "version": "0.8.3",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
             "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+            "peer": true,
             "dependencies": {
                 "deep-is": "~0.1.3",
                 "fast-levenshtein": "~2.0.6",
@@ -3062,6 +3082,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
             "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -3070,6 +3091,7 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
             "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "~1.1.2"
             },
@@ -3416,6 +3438,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "peer": true,
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -3946,6 +3969,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
             "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+            "peer": true,
             "dependencies": {
                 "whatwg-encoding": "^2.0.0"
             },
@@ -3957,6 +3981,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "peer": true,
             "dependencies": {
                 "@tootallnate/once": "2",
                 "agent-base": "6",
@@ -3970,6 +3995,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "peer": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -4219,7 +4245,8 @@
         "node_modules/is-potential-custom-element-name": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "peer": true
         },
         "node_modules/is-regex": {
             "version": "1.1.4",
@@ -4331,6 +4358,7 @@
             "version": "20.0.3",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
             "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+            "peer": true,
             "dependencies": {
                 "abab": "^2.0.6",
                 "acorn": "^8.8.1",
@@ -4375,6 +4403,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
             "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.1"
             },
@@ -4386,6 +4415,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -4394,6 +4424,7 @@
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
             "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+            "peer": true,
             "dependencies": {
                 "tr46": "^3.0.0",
                 "webidl-conversions": "^7.0.0"
@@ -4703,7 +4734,8 @@
         "node_modules/nwsapi": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-            "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw=="
+            "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
+            "peer": true
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
@@ -4875,6 +4907,7 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
             "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+            "peer": true,
             "dependencies": {
                 "entities": "^4.4.0"
             },
@@ -5159,7 +5192,8 @@
         "node_modules/psl": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+            "peer": true
         },
         "node_modules/punycode": {
             "version": "2.1.1",
@@ -5181,7 +5215,8 @@
         "node_modules/querystringify": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+            "peer": true
         },
         "node_modules/queue-lit": {
             "version": "1.3.0",
@@ -5270,7 +5305,8 @@
         "node_modules/requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+            "peer": true
         },
         "node_modules/resolve": {
             "version": "1.22.1",
@@ -5392,6 +5428,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
             "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "peer": true,
             "dependencies": {
                 "xmlchars": "^2.2.0"
             },
@@ -5590,7 +5627,8 @@
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "peer": true
         },
         "node_modules/synckit": {
             "version": "0.8.4",
@@ -5688,6 +5726,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
             "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+            "peer": true,
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -5838,6 +5877,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
             "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -5890,6 +5930,7 @@
             "version": "1.5.10",
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+            "peer": true,
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -6080,6 +6121,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
             "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+            "peer": true,
             "dependencies": {
                 "xml-name-validator": "^4.0.0"
             },
@@ -6097,6 +6139,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
             "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+            "peer": true,
             "dependencies": {
                 "iconv-lite": "0.6.3"
             },
@@ -6108,6 +6151,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
             "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -6177,6 +6221,7 @@
             "version": "8.11.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
             "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -6204,7 +6249,8 @@
         "node_modules/xmlchars": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "peer": true
         },
         "node_modules/xtend": {
             "version": "4.0.2",
@@ -6829,6 +6875,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.1.3.tgz",
             "integrity": "sha512-9/7y7Gh8IydD1mSbUEaIv4I2/XzQeH/d5HZvIeEfdcARoQWnZSVOPVH1r3h7RH5UyuSeTeJUeevqPj3HxsRN8Q==",
+            "peer": true,
             "requires": {
                 "jsdom": "^20.0.3"
             }
@@ -6870,7 +6917,8 @@
         "@tootallnate/once": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "peer": true
         },
         "@trysound/sax": {
             "version": "0.2.0",
@@ -7241,7 +7289,8 @@
         "abab": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-            "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
+            "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+            "peer": true
         },
         "acorn": {
             "version": "8.8.1",
@@ -7252,6 +7301,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
             "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+            "peer": true,
             "requires": {
                 "acorn": "^8.1.0",
                 "acorn-walk": "^8.0.2"
@@ -7260,7 +7310,8 @@
                 "acorn-walk": {
                     "version": "8.2.0",
                     "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-                    "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+                    "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+                    "peer": true
                 }
             }
         },
@@ -7297,6 +7348,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "peer": true,
             "requires": {
                 "debug": "4"
             }
@@ -7642,12 +7694,14 @@
         "cssom": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-            "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
+            "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+            "peer": true
         },
         "cssstyle": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
             "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+            "peer": true,
             "requires": {
                 "cssom": "~0.3.6"
             },
@@ -7655,7 +7709,8 @@
                 "cssom": {
                     "version": "0.3.8",
                     "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-                    "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+                    "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+                    "peer": true
                 }
             }
         },
@@ -7932,6 +7987,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
             "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+            "peer": true,
             "requires": {
                 "abab": "^2.0.6",
                 "whatwg-mimetype": "^3.0.0",
@@ -7942,6 +7998,7 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
                     "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+                    "peer": true,
                     "requires": {
                         "punycode": "^2.1.1"
                     }
@@ -7949,12 +8006,14 @@
                 "webidl-conversions": {
                     "version": "7.0.0",
                     "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-                    "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+                    "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+                    "peer": true
                 },
                 "whatwg-url": {
                     "version": "11.0.0",
                     "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
                     "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+                    "peer": true,
                     "requires": {
                         "tr46": "^3.0.0",
                         "webidl-conversions": "^7.0.0"
@@ -7990,7 +8049,8 @@
         "decimal.js": {
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+            "peer": true
         },
         "deep-is": {
             "version": "0.1.4",
@@ -8090,6 +8150,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
             "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+            "peer": true,
             "requires": {
                 "webidl-conversions": "^7.0.0"
             },
@@ -8097,7 +8158,8 @@
                 "webidl-conversions": {
                     "version": "7.0.0",
                     "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-                    "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+                    "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+                    "peer": true
                 }
             }
         },
@@ -8246,6 +8308,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
             "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+            "peer": true,
             "requires": {
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
@@ -8257,12 +8320,14 @@
                 "estraverse": {
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+                    "peer": true
                 },
                 "levn": {
                     "version": "0.3.0",
                     "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
                     "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+                    "peer": true,
                     "requires": {
                         "prelude-ls": "~1.1.2",
                         "type-check": "~0.3.2"
@@ -8272,6 +8337,7 @@
                     "version": "0.8.3",
                     "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
                     "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+                    "peer": true,
                     "requires": {
                         "deep-is": "~0.1.3",
                         "fast-levenshtein": "~2.0.6",
@@ -8284,12 +8350,14 @@
                 "prelude-ls": {
                     "version": "1.1.2",
                     "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                    "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
+                    "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+                    "peer": true
                 },
                 "type-check": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
                     "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+                    "peer": true,
                     "requires": {
                         "prelude-ls": "~1.1.2"
                     }
@@ -8559,7 +8627,8 @@
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "peer": true
         },
         "esquery": {
             "version": "1.4.0",
@@ -8939,6 +9008,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
             "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+            "peer": true,
             "requires": {
                 "whatwg-encoding": "^2.0.0"
             }
@@ -8947,6 +9017,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "peer": true,
             "requires": {
                 "@tootallnate/once": "2",
                 "agent-base": "6",
@@ -8957,6 +9028,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "peer": true,
             "requires": {
                 "agent-base": "6",
                 "debug": "4"
@@ -9122,7 +9194,8 @@
         "is-potential-custom-element-name": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "peer": true
         },
         "is-regex": {
             "version": "1.1.4",
@@ -9204,6 +9277,7 @@
             "version": "20.0.3",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
             "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+            "peer": true,
             "requires": {
                 "abab": "^2.0.6",
                 "acorn": "^8.8.1",
@@ -9237,6 +9311,7 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
                     "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+                    "peer": true,
                     "requires": {
                         "punycode": "^2.1.1"
                     }
@@ -9244,12 +9319,14 @@
                 "webidl-conversions": {
                     "version": "7.0.0",
                     "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-                    "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+                    "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+                    "peer": true
                 },
                 "whatwg-url": {
                     "version": "11.0.0",
                     "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
                     "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+                    "peer": true,
                     "requires": {
                         "tr46": "^3.0.0",
                         "webidl-conversions": "^7.0.0"
@@ -9489,7 +9566,8 @@
         "nwsapi": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-            "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw=="
+            "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
+            "peer": true
         },
         "object-assign": {
             "version": "4.1.1",
@@ -9607,6 +9685,7 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
             "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+            "peer": true,
             "requires": {
                 "entities": "^4.4.0"
             }
@@ -9791,7 +9870,8 @@
         "psl": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+            "peer": true
         },
         "punycode": {
             "version": "2.1.1",
@@ -9806,7 +9886,8 @@
         "querystringify": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+            "peer": true
         },
         "queue-lit": {
             "version": "1.3.0",
@@ -9860,7 +9941,8 @@
         "requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+            "peer": true
         },
         "resolve": {
             "version": "1.22.1",
@@ -9939,6 +10021,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
             "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "peer": true,
             "requires": {
                 "xmlchars": "^2.2.0"
             }
@@ -10073,7 +10156,8 @@
         "symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "peer": true
         },
         "synckit": {
             "version": "0.8.4",
@@ -10149,6 +10233,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
             "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+            "peer": true,
             "requires": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -10262,7 +10347,8 @@
         "universalify": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
+            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+            "peer": true
         },
         "update-browserslist-db": {
             "version": "1.0.9",
@@ -10303,6 +10389,7 @@
             "version": "1.5.10",
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+            "peer": true,
             "requires": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -10424,6 +10511,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
             "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+            "peer": true,
             "requires": {
                 "xml-name-validator": "^4.0.0"
             }
@@ -10438,6 +10526,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
             "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+            "peer": true,
             "requires": {
                 "iconv-lite": "0.6.3"
             }
@@ -10445,7 +10534,8 @@
         "whatwg-mimetype": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
+            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+            "peer": true
         },
         "whatwg-url": {
             "version": "5.0.0",
@@ -10500,6 +10590,7 @@
             "version": "8.11.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
             "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+            "peer": true,
             "requires": {}
         },
         "xml-name-validator": {
@@ -10510,7 +10601,8 @@
         "xmlchars": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "peer": true
         },
         "xtend": {
             "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,8 +39,8 @@
                 "vue-tsc": "1.0.19"
             },
             "peerDependencies": {
-                "@prefecthq/prefect-design": "1.1.43",
-                "@prefecthq/vue-compositions": "1.1.3",
+                "@prefecthq/prefect-design": "^1.1.43",
+                "@prefecthq/vue-compositions": "^1.1.3",
                 "vee-validate": "^4.5.11",
                 "vue": "^3.2.45",
                 "vue-router": "^4.0.12"

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
         "vue-tsc": "1.0.19"
     },
     "peerDependencies": {
-        "@prefecthq/prefect-design": "1.1.43",
-        "@prefecthq/vue-compositions": "1.1.3",
+        "@prefecthq/prefect-design": "^1.1.43",
+        "@prefecthq/vue-compositions": "^1.1.3",
         "vee-validate": "^4.5.11",
         "vue": "^3.2.45",
         "vue-router": "^4.0.12"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
         "vue-tsc": "1.0.19"
     },
     "peerDependencies": {
-        "@prefecthq/prefect-design": "^1.1.43",
+        "@prefecthq/prefect-design": "1.1.43",
+        "@prefecthq/vue-compositions": "1.1.3",
         "vee-validate": "^4.5.11",
         "vue": "^3.2.45",
         "vue-router": "^4.0.12"
@@ -68,7 +69,6 @@
         "@prefecthq/graphs": "0.1.8",
         "@prefecthq/radar": "0.0.17",
         "@prefecthq/vue-charts": "0.0.19",
-        "@prefecthq/vue-compositions": "1.1.3",
         "axios": "0.27.2",
         "cronstrue": "^2.21.0",
         "date-fns": "2.29.3",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,8 +42,7 @@ export default defineConfig(({ mode }) => {
         name: 'orion-design',
       },
       rollupOptions: {
-      // ensures vue isn't added to the bundle
-        external: ['vue', 'vue-router', 'vee-validate'],
+        external: ['vue', 'vue-router', 'vee-validate', '@prefecthq/vue-compositions', '@prefecthq/prefect-design'],
         output: {
           exports: 'named',
           // Provide vue as a global variable to use in the UMD build


### PR DESCRIPTION
# Description
We've had some issues with both prefect-design and vue-compositions not playing nicely across orion-design and orion-ui/nebula-ui. Thinks like subscriptions not being shared and messed up UI styles for tables. 

prefect-design was already a peer dependency but vue-compositions was not. They both should be peers so I updated vue-compositions to be a peer. 

Any peer dependencies must also be marked as external in the vite config otherwise they will be bundle with orion-design when it is published. 

Making them both external dependencies in the PR with removes them from the bundle and imports them directly from whatever project orion-design is added too. This makes the bundle smaller but more importantly should fix the above mentioned issues. 

I can verify the subscription sharing but is fixed by this. Visiting a flow run page has two identical subscriptions. One in orion-ui and one in orion-design. 

Before
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/6200442/210456116-2454f467-aae6-454e-9657-8c50c28fe754.png">

After
<img width="1240" alt="image" src="https://user-images.githubusercontent.com/6200442/210456206-56cb1640-84cb-49aa-956e-8825b807dc23.png">
