### PR TITLE
BugFix: Prevent errors when guessing the definition for a schema property value. 

### DIFF
--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -175,7 +175,7 @@ export function resolve<T>(value: T, resolvers: ResolverCallback<T>[]): T {
 export function getSchemaValueAnyOfDefinition(property: SchemaPropertyAnyOf, value: SchemaValue): Schema | null {
   const index = getSchemaValueAnyOfDefinitionIndex(property, value)
 
-  if (index === null) {
+  if (index === null || index === -1) {
     console.warn('Schema property with anyOf had a value but could not be associated with a definition')
 
     return null


### PR DESCRIPTION
# Description
Because of how definitions work for nested blocks, sometimes we have to guess what the definition is. If we cannot guess we try and safely fallback. A check was missing in the fallback that was causing it to error. 

Closes https://github.com/PrefectHQ/orion-design/issues/979

Note: This doesn't solve the issue that we sometimes cannot guess the correct definition. Specifically if a property is a union of two blocks we're unable to guess because the value is a guid.