### PR TITLE
update graphs dependency and add short time format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@prefecthq/orion-design",
             "version": "1.1.50",
             "dependencies": {
-                "@prefecthq/graphs": "0.1.8",
+                "@prefecthq/graphs": "0.1.9",
                 "@prefecthq/radar": "0.0.17",
                 "@prefecthq/vue-charts": "0.0.19",
                 "axios": "0.27.2",
@@ -936,9 +936,9 @@
             }
         },
         "node_modules/@prefecthq/graphs": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.8.tgz",
-            "integrity": "sha512-TceB8axvT2PXDIwGgd0wVeKXK8kjfkNJBcP7ce6gOIS++fgc4NzeAxvYmD9h3r+/9UN7/vwsvADGeLyToVeFYg==",
+            "version": "0.1.9",
+            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.9.tgz",
+            "integrity": "sha512-+9jfr+y2dHWdZbh7kUJBYLNJiViquSmuKJU1Z+ZPCLAKQnVegO9cBmZoNW+USzzje+XOWS9ODOFR71zmnxLRKA==",
             "dependencies": {
                 "@pixi-essentials/cull": "^1.1.0",
                 "@prefecthq/vue-compositions": "1.0.0",
@@ -948,7 +948,7 @@
                 "pixi.js": "^6.5.8"
             },
             "peerDependencies": {
-                "@prefecthq/prefect-design": "^1.1.39",
+                "@prefecthq/prefect-design": "^1.1.43",
                 "vue": "^3.2.45",
                 "vue-router": "^4.0.12"
             }
@@ -6777,9 +6777,9 @@
             }
         },
         "@prefecthq/graphs": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.8.tgz",
-            "integrity": "sha512-TceB8axvT2PXDIwGgd0wVeKXK8kjfkNJBcP7ce6gOIS++fgc4NzeAxvYmD9h3r+/9UN7/vwsvADGeLyToVeFYg==",
+            "version": "0.1.9",
+            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.9.tgz",
+            "integrity": "sha512-+9jfr+y2dHWdZbh7kUJBYLNJiViquSmuKJU1Z+ZPCLAKQnVegO9cBmZoNW+USzzje+XOWS9ODOFR71zmnxLRKA==",
             "requires": {
                 "@pixi-essentials/cull": "^1.1.0",
                 "@prefecthq/vue-compositions": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "vue-router": "^4.0.12"
     },
     "dependencies": {
-        "@prefecthq/graphs": "0.1.8",
+        "@prefecthq/graphs": "0.1.9",
         "@prefecthq/radar": "0.0.17",
         "@prefecthq/vue-charts": "0.0.19",
         "axios": "0.27.2",

--- a/src/components/FlowRunTimeline.vue
+++ b/src/components/FlowRunTimeline.vue
@@ -6,6 +6,9 @@
     <FlowRunTimeline
       :graph-data="graphData"
       :is-running="isRunning"
+      :format-time-by-seconds="formatTimeNumeric"
+      :format-time-by-minutes="formatTimeShortNumeric"
+      :format-date="formatDate"
     />
   </div>
 </template>
@@ -17,6 +20,7 @@
   import { BetaBadge } from '@/components'
   import { useWorkspaceApi } from '@/compositions'
   import { FlowRun, isValidTimelineNodeData } from '@/models'
+  import { formatTimeNumeric, formatTimeShortNumeric, formatDate } from '@/utilities'
 
   const props = defineProps<{
     flowRun: FlowRun,

--- a/src/utilities/dates.ts
+++ b/src/utilities/dates.ts
@@ -4,6 +4,7 @@ import { dateFunctions, toDate, formatDateInTimezone } from '@/utilities/timezon
 
 const dateTimeNumericFormat = 'yyyy/MM/dd hh:mm:ss a'
 const timeNumericFormat = 'hh:mm:ss a'
+const timeNumericShortFormat = 'hh:mm a'
 const dateFormat = 'MMM do, yyyy'
 
 export {
@@ -60,6 +61,10 @@ export function parseDateTimeNumeric(value: string, reference: Date = new Date()
 
 export function formatTimeNumeric(value: Date | string): string {
   return formatDate(value, timeNumericFormat)
+}
+
+export function formatTimeShortNumeric(value: Date | string): string {
+  return formatDate(value, timeNumericShortFormat)
 }
 
 export function parseTimeNumeric(value: string, reference: Date = new Date()): Date {


### PR DESCRIPTION
Update the graphs dependency to 0.1.9

The FlowRunTimeline graph now requires date formatting methods to be passed in. One is `format-time-by-minutes` which is intended for a short form time label when a series of times are listed by minute, and showing seconds adds no value. A time format was added for this use case.