### PR TITLE
BugFix: utc timezone selection in deployment schedule

### DIFF
--- a/src/utilities/timezone.ts
+++ b/src/utilities/timezone.ts
@@ -5,7 +5,7 @@ import { isDate } from '@/utilities/dates'
 
 export const selectedTimezone = ref<string | null>(null)
 
-export const utcTimezone = '-00:00'
+export const utcTimezone = 'Etc/UTC'
 export function timezoneIsUtc(timezone: string): timezone is typeof utcTimezone {
   return timezone === utcTimezone
 }


### PR DESCRIPTION
this PR switches utc option to iana named timezone, which works for both date-fns-tz and also our API for things like deployment schedules

closes #1005 