### PR TITLE
Chore: Revert to vue-compositions 1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
             },
             "peerDependencies": {
                 "@prefecthq/prefect-design": "^1.1.43",
-                "@prefecthq/vue-compositions": "^1.1.3",
+                "@prefecthq/vue-compositions": "1.1.2",
                 "vee-validate": "^4.5.11",
                 "vue": "^3.2.45",
                 "vue-router": "^4.0.12"
@@ -1053,9 +1053,9 @@
             }
         },
         "node_modules/@prefecthq/vue-compositions": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.1.3.tgz",
-            "integrity": "sha512-9/7y7Gh8IydD1mSbUEaIv4I2/XzQeH/d5HZvIeEfdcARoQWnZSVOPVH1r3h7RH5UyuSeTeJUeevqPj3HxsRN8Q==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.1.2.tgz",
+            "integrity": "sha512-8tGCm7msA/p3jpqgF+I48Pc2aSs3OPexBrPiLYZxgm0oFLV0zfp3gKx0ZTaB/BfaGVA86qEG0cq7qRkWzcnAHg==",
             "peer": true,
             "dependencies": {
                 "jsdom": "^20.0.3"
@@ -6872,9 +6872,9 @@
             }
         },
         "@prefecthq/vue-compositions": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.1.3.tgz",
-            "integrity": "sha512-9/7y7Gh8IydD1mSbUEaIv4I2/XzQeH/d5HZvIeEfdcARoQWnZSVOPVH1r3h7RH5UyuSeTeJUeevqPj3HxsRN8Q==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.1.2.tgz",
+            "integrity": "sha512-8tGCm7msA/p3jpqgF+I48Pc2aSs3OPexBrPiLYZxgm0oFLV0zfp3gKx0ZTaB/BfaGVA86qEG0cq7qRkWzcnAHg==",
             "peer": true,
             "requires": {
                 "jsdom": "^20.0.3"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     },
     "peerDependencies": {
         "@prefecthq/prefect-design": "^1.1.43",
-        "@prefecthq/vue-compositions": "^1.1.3",
+        "@prefecthq/vue-compositions": "1.1.2",
         "vee-validate": "^4.5.11",
         "vue": "^3.2.45",
         "vue-router": "^4.0.12"


### PR DESCRIPTION
Reverts to vue-compositions 1.1.2 because of suspected bugs in 1.1.3 and 1.2.0