### PR TITLE
Chore: Remove pause/active status select from worker related forms

### DIFF
--- a/src/components/WorkerPoolCreateForm.vue
+++ b/src/components/WorkerPoolCreateForm.vue
@@ -21,14 +21,6 @@
         <!-- <WorkerPoolTypeSelect v-model:selected="type" :state="typeState" /> -->
       </p-label>
 
-      <p-label label="Status (Optional)">
-        <p-toggle v-model="isActive">
-          <template #append>
-            {{ isActiveLabel }}
-          </template>
-        </p-toggle>
-      </p-label>
-
       <p-label label="Flow Run Concurrency (Optional)">
         <template #default="{ id }">
           <p-number-input :id="id" v-model="concurrencyLimit" placeholder="Unlimited" :min="0" />
@@ -48,7 +40,7 @@
 <script lang="ts" setup>
   import { showToast } from '@prefecthq/prefect-design'
   import { useValidation, useValidationObserver, ValidationRule } from '@prefecthq/vue-compositions'
-  import { computed, ref } from 'vue'
+  import { ref } from 'vue'
   import { useRouter } from 'vue-router'
   import { SubmitButton } from '@/components'
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
@@ -66,8 +58,6 @@
   // const type = ref<string>()
   const type = ref<string>('prefect-agent')
   const concurrencyLimit = ref<number>()
-  const isActive = ref<boolean>(true)
-  const isActiveLabel = computed(() => isActive.value ? 'Active' : 'Paused')
 
   const isRequired: ValidationRule<string | undefined> = (value) => value !== undefined && value.trim().length > 0
 
@@ -90,7 +80,7 @@
         name: name.value,
         description: description.value,
         type: type.value,
-        isPaused: !isActive.value,
+        isPaused: false,
         concurrencyLimit: concurrencyLimit.value,
       }
 

--- a/src/components/WorkerPoolEditForm.vue
+++ b/src/components/WorkerPoolEditForm.vue
@@ -19,14 +19,6 @@
         </template>
       </p-label>
 
-      <p-label label="Status (Optional)">
-        <p-toggle v-model="isActive">
-          <template #append>
-            {{ isActiveLabel }}
-          </template>
-        </p-toggle>
-      </p-label>
-
       <p-label label="Flow Run Concurrency (Optional)">
         <template #default="{ id }">
           <p-number-input :id="id" v-model="concurrencyLimit" placeholder="Unlimited" :min="0" />
@@ -64,8 +56,6 @@
 
   const description = ref<string | null | undefined>(props.workerPool.description)
   const concurrencyLimit = ref<number | null | undefined>(props.workerPool.concurrencyLimit)
-  const isActive = ref<boolean | undefined>(!props.workerPool.isPaused)
-  const isActiveLabel = computed(() => isActive.value ? 'Active' : 'Paused')
 
   function cancel(): void {
     router.back()
@@ -76,7 +66,6 @@
     if (valid) {
       const values = {
         description: description.value,
-        isPaused: !isActive.value,
         concurrencyLimit: concurrencyLimit.value,
       }
       try {

--- a/src/components/WorkerPoolQueueCreateForm.vue
+++ b/src/components/WorkerPoolQueueCreateForm.vue
@@ -13,14 +13,6 @@
         </template>
       </p-label>
 
-      <p-label label="Status (Optional)">
-        <p-toggle v-model="isActive">
-          <template #append>
-            {{ isActiveLabel }}
-          </template>
-        </p-toggle>
-      </p-label>
-
       <p-label label="Flow Run Concurrency (Optional)">
         <template #default="{ id }">
           <p-number-input :id="id" v-model="concurrencyLimit" placeholder="Unlimited" :min="0" />
@@ -45,7 +37,7 @@
   <script lang="ts" setup>
   import { showToast } from '@prefecthq/prefect-design'
   import { useValidation, useValidationObserver, ValidationRule } from '@prefecthq/vue-compositions'
-  import { computed, ref } from 'vue'
+  import { ref } from 'vue'
   import { useRouter } from 'vue-router'
   import { SubmitButton } from '@/components'
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
@@ -63,9 +55,6 @@
   const name = ref<string>()
   const description = ref<string>()
   const concurrencyLimit = ref<number>()
-  const isActive = ref<boolean>(true)
-  const isActiveLabel = computed(() => isActive.value ? 'Active' :
-    'Paused')
   const queuePriority = ref<number>()
 
   const isRequired: ValidationRule<string | undefined> = (value) => value !== undefined && value.trim().length > 0
@@ -95,7 +84,7 @@
     const values = {
       name: name.value,
       description: description.value,
-      isPaused: !isActive.value,
+      isPaused: false,
       concurrencyLimit: concurrencyLimit.value,
       priority: queuePriority.value,
     }

--- a/src/components/WorkerPoolQueueEditForm.vue
+++ b/src/components/WorkerPoolQueueEditForm.vue
@@ -6,23 +6,19 @@
           <p-text-input :id="id" v-model="name" :state="nameState" />
         </template>
       </p-label>
+
       <p-label label="Description (Optional)">
         <template #default="{ id }">
           <p-textarea :id="id" v-model="description" rows="7" />
         </template>
       </p-label>
-      <p-label label="Status (Optional)">
-        <p-toggle v-model="isActive">
-          <template #append>
-            {{ isActiveLabel }}
-          </template>
-        </p-toggle>
-      </p-label>
+
       <p-label label="Flow Run Concurrency (Optional)">
         <template #default="{ id }">
           <p-number-input :id="id" v-model="concurrencyLimit" placeholder="Unlimited" :min="0" />
         </template>
       </p-label>
+
       <p-label label="Priority" :message="queuePriorityErrorMessage" :state="queuePriorityState">
         <template #default="{ id }">
           <p-number-input :id="id" v-model="queuePriority" :min="1" :state="queuePriorityState" />
@@ -42,7 +38,7 @@
   <script lang="ts" setup>
   import { showToast } from '@prefecthq/prefect-design'
   import { useValidation, useValidationObserver, ValidationRule } from '@prefecthq/vue-compositions'
-  import { computed, ref } from 'vue'
+  import { ref } from 'vue'
   import { useRouter } from 'vue-router'
   import { SubmitButton } from '@/components'
   import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
@@ -63,8 +59,6 @@
   const description = ref<string | null | undefined>(props.workerPoolQueue.description)
   const concurrencyLimit = ref<number | null | undefined>(props.workerPoolQueue.concurrencyLimit)
   const queuePriority = ref<number>(props.workerPoolQueue.priority)
-  const isActive = ref<boolean | undefined>(!props.workerPoolQueue.isPaused)
-  const isActiveLabel = computed(() => isActive.value ? 'Active' : 'Paused')
 
   const isRequired: ValidationRule<string | undefined> = (value) => value !== undefined && value.trim().length > 0
 
@@ -89,7 +83,6 @@
       const values = {
         name: name.value,
         description: description.value,
-        isPaused: !isActive.value,
         concurrencyLimit: concurrencyLimit.value,
         priority: queuePriority.value,
       }


### PR DESCRIPTION
This PR removes the pause/active toggle as per discussion [here](https://prefecthq.slack.com/archives/C04F1PTMUCQ/p1673030623597329?thread_ts=1672946322.925419&cid=C04F1PTMUCQ)