### PR TITLE
Feature: hide timestamp from TimezoneSelect by default

### DIFF
--- a/demo/sections/TimezoneSupport.vue
+++ b/demo/sections/TimezoneSupport.vue
@@ -6,7 +6,7 @@
       </p-label>
 
       <p-label label="Timezone">
-        <TimezoneSelect v-model="selectedTimezone">
+        <TimezoneSelect v-model="selectedTimezone" show-timestamp>
           <template #empty-message>
             <em class="gray-400">browser default</em>
           </template>

--- a/src/components/TimezoneSelect.vue
+++ b/src/components/TimezoneSelect.vue
@@ -14,6 +14,7 @@
 
   const props = defineProps<{
     modelValue: string | null,
+    showTimestamp?: boolean,
   }>()
 
   const emit = defineEmits<{
@@ -30,7 +31,7 @@
   })
 
   const currentTime = ref(new Date())
-  const timestamp = computed(() => formatDateInTimezone(currentTime.value, 'hh:mm a', props.modelValue))
+  const timestamp = computed(() => props.showTimestamp ? formatDateInTimezone(currentTime.value, 'hh:mm a', props.modelValue) : undefined)
 
   function updateCurrentTime(): void {
     currentTime.value = new Date()


### PR DESCRIPTION
the timezone select uses the append slot to display an example of what the current time would be in the selected timezone. upon closer review, this doesn't make sense for situations where the timezone select is right next to a datepicker. The user would expect to A: be able to edit that time from here. B: expect the time to be the one selected from the other component, not the current time.

before:
<img width="835" alt="image" src="https://user-images.githubusercontent.com/6098901/211427502-d265bba8-5b6c-49a8-b9c2-49a3969a9af8.png">

after: 
<img width="828" alt="image" src="https://user-images.githubusercontent.com/6098901/211427383-559464c4-4ebe-45b1-96ad-d94d438d9699.png">
