### PR TITLE
Bugfix: Make state badge text color important

### DIFF
--- a/src/components/StateBadge.vue
+++ b/src/components/StateBadge.vue
@@ -46,7 +46,7 @@
 .state-badge__icon { @apply
   w-4
   h-4
-  text-inherit
+  !text-inherit
 }
 
 .state-badge--flat { @apply


### PR DESCRIPTION
In the final build base state classes have higher specificity than the classes coming from this component. Worth figuring out why that's the case but for now this will make sure this component renders properly.