### PR TITLE
Chore: Remove 3 dot menu on Notifications if the user doesn't have permission to edit/delete

### DIFF
--- a/src/components/NotificationMenu.vue
+++ b/src/components/NotificationMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-icon-button-menu v-if="can.update.notification_policy">
+  <p-icon-button-menu>
     <p-overflow-menu-item v-if="false" label="Send Test" />
     <router-link v-if="can.update.notification_policy" :to="routes.notificationEdit(notification.id)">
       <p-overflow-menu-item label="Edit" />

--- a/src/components/NotificationMenu.vue
+++ b/src/components/NotificationMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-icon-button-menu>
+  <p-icon-button-menu v-if="can.update.notification_policy">
     <p-overflow-menu-item v-if="false" label="Send Test" />
     <router-link v-if="can.update.notification_policy" :to="routes.notificationEdit(notification.id)">
       <p-overflow-menu-item label="Edit" />

--- a/src/components/NotificationsTable.vue
+++ b/src/components/NotificationsTable.vue
@@ -54,6 +54,7 @@
   import NotificationStatusSelect from '@/components/NotificationStatusSelect.vue'
   import NotificationToggle from '@/components/NotificationToggle.vue'
   import ResultsCount from '@/components/ResultsCount.vue'
+  import { useCan } from '@/compositions'
   import { Notification, NotificationStatus } from '@/models'
 
   const props = defineProps<{
@@ -68,6 +69,8 @@
   const selectedStatus = ref<NotificationStatus>('all')
   const hasFilter = computed(() => selectedStatus.value !== 'all')
 
+  const can = useCan()
+
   const columns = [
     {
       property: 'notification',
@@ -76,6 +79,7 @@
     {
       label: 'Action',
       width: '42px',
+      visible: can.update.notification_policy,
     },
   ]
 
@@ -111,5 +115,6 @@
 .notifications-table__actions { @apply
   flex
   gap-2
+  items-center
 }
 </style>


### PR DESCRIPTION
This PR hides the 3-dot menu if the user doesn't have permission to interact with it. Also, finally fixes alignment between menu and toggle

Closes https://github.com/PrefectHQ/orion-design/issues/919