### PR TITLE
Enhancement: Support displaying an anonymous block in the BlockCapabilityBlockDocumentInput

### DIFF
--- a/src/components/BlockCapabilityBlockDocumentInput.vue
+++ b/src/components/BlockCapabilityBlockDocumentInput.vue
@@ -100,7 +100,18 @@
     return [filter]
   })
   const blockDocumentsSubscription = useSubscriptionWithDependencies(api.blockDocuments.getBlockDocuments, blockDocumentFilter)
-  const blockDocuments = computed(() => blockDocumentsSubscription.response ?? [])
+  const blockDocuments = computed(() => {
+    const documents = blockDocumentsSubscription.response ?? []
+
+    if (blockDocument.value && !documents.some(document => document.id === blockDocument.value?.id)) {
+      documents.push({
+        ...blockDocument.value,
+        name: 'Anonymous Block',
+      })
+    }
+
+    return documents
+  })
 
   const options = computed<SelectOptionGroup[]>(() => blockTypes.value.flatMap(blockType => {
     const documents = blockDocuments.value.filter(blockDocument => blockDocument.blockTypeId === blockType.id)


### PR DESCRIPTION
# Description
Solves an issue with migrating notifications over to automations where notifications use anonymous blocks. We don't want anonymous blocks to show up in the list but if the selected value is an anonymous block we can display it. 