### PR TITLE
BugFix: Hide browser default option when editing deployment schedules

### DIFF
--- a/src/components/DeploymentDetails.vue
+++ b/src/components/DeploymentDetails.vue
@@ -132,6 +132,7 @@
     updateScheduleLoading.value = true
 
     try {
+      console.log('schedule', schedule)
       await api.deployments.updateDeployment(props.deployment.id, { schedule })
 
       emit('update')

--- a/src/components/DeploymentDetails.vue
+++ b/src/components/DeploymentDetails.vue
@@ -132,7 +132,6 @@
     updateScheduleLoading.value = true
 
     try {
-      console.log('schedule', schedule)
       await api.deployments.updateDeployment(props.deployment.id, { schedule })
 
       emit('update')

--- a/src/components/IntervalScheduleForm.vue
+++ b/src/components/IntervalScheduleForm.vue
@@ -22,7 +22,7 @@
         </p-label>
 
         <p-label label="Timezone" class="interval-schedule-form__column--span-2">
-          <TimezoneSelect v-model="timezone" />
+          <TimezoneSelect v-model="timezone" hide-unset />
         </p-label>
       </div>
     </p-content>

--- a/src/components/TimezoneSelect.vue
+++ b/src/components/TimezoneSelect.vue
@@ -15,6 +15,7 @@
   const props = defineProps<{
     modelValue: string | null,
     showTimestamp?: boolean,
+    hideUnset?: boolean,
   }>()
 
   const emit = defineEmits<{
@@ -47,12 +48,13 @@
 
   onUnmounted(() => clearTimeout(timeout))
 
-  const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
-
   const timezones = Intl.supportedValuesOf('timeZone').map(timezone => ({ label: timezone, value: timezone }))
   const options: SelectOption[] = [
-    { label: 'Use browser default', value: localTimezone },
     { label: 'UTC', value: utcTimezone },
     ...timezones,
   ]
+
+  if (!props.hideUnset) {
+    options.unshift({ label: 'Use browser default', value: null })
+  }
 </script>

--- a/src/components/TimezoneSelect.vue
+++ b/src/components/TimezoneSelect.vue
@@ -47,9 +47,11 @@
 
   onUnmounted(() => clearTimeout(timeout))
 
+  const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
   const timezones = Intl.supportedValuesOf('timeZone').map(timezone => ({ label: timezone, value: timezone }))
   const options: SelectOption[] = [
-    { label: 'Use browser default', value: null },
+    { label: 'Use browser default', value: localTimezone },
     { label: 'UTC', value: utcTimezone },
     ...timezones,
   ]


### PR DESCRIPTION
Current behavior:
If I create an interval schedule and select "Use browser default" the timezone is sent as null, which the api interprets as UTC.  The timezone that is sent back is shown as UTC. 

Fix:
This adds the local timezone string to send the correct value to the api. 

I'd appreciate eyes on from @stackoverfloweth here as I know he did a lot of timezone work and I don't want this to mess any of that up! 