### PR TITLE
BugFix: loosen requirements to call httpStatus utility

### DIFF
--- a/src/utilities/httpStatus.ts
+++ b/src/utilities/httpStatus.ts
@@ -15,7 +15,8 @@ function isAxiosResponse(value: unknown): value is AxiosResponse {
 }
 
 function isAxiosError(value: unknown): value is AxiosError {
-  return value instanceof AxiosError
+  const error = value as AxiosError
+  return isAxiosResponse(error.response)
 }
 
 function getStatusCode(value: unknown): number {

--- a/src/utilities/httpStatus.ts
+++ b/src/utilities/httpStatus.ts
@@ -14,7 +14,11 @@ function isAxiosResponse(value: unknown): value is AxiosResponse {
   return typeof response.status === 'number'
 }
 
-function getStatusCode(value: AxiosError | AxiosResponse | number): number {
+function isAxiosError(value: unknown): value is AxiosError {
+  return value instanceof AxiosError
+}
+
+function getStatusCode(value: unknown): number {
   if (typeof value === 'number') {
     return value
   }
@@ -23,14 +27,14 @@ function getStatusCode(value: AxiosError | AxiosResponse | number): number {
     return value.status
   }
 
-  if (value.response) {
+  if (isAxiosError(value)) {
     return getStatusCode(value.response)
   }
 
   throw 'Invalid argument provided to httpStatus'
 }
 
-export function httpStatus(value: AxiosError | AxiosResponse | number): HttpStatusResponse {
+export function httpStatus(value: unknown): HttpStatusResponse {
   const status = getStatusCode(value)
 
   return {
@@ -39,7 +43,7 @@ export function httpStatus(value: AxiosError | AxiosResponse | number): HttpStat
   }
 }
 
-const httpStatusCode = {
+export const httpStatusCode = {
   Continue: 100,
   SwitchingProtocols: 101,
   Processing: 102,


### PR DESCRIPTION
this function already does a lot of type guard checks, it just needed to loosen it's param type to enable the following syntax

```ts
try {
   // something sketch
} catch(error) {
   // typeof error here is `unknown`
   if (httpStatus(error).is('Forbidden')) {
      // now we know error is `AxiosError | AxiosResponse | number` and the status code was 403    
   }
}
```