### PR TITLE
Chore: Updates permissions for work pool queue components and pages

### DIFF
--- a/src/components/WorkPoolQueueMenu.vue
+++ b/src/components/WorkPoolQueueMenu.vue
@@ -2,7 +2,7 @@
   <p-icon-button-menu v-bind="$attrs" class="work-pool-queue-menu">
     <CopyOverflowMenuItem label="Copy ID" :item="workPoolQueue.id" />
     <router-link :to="routes.workPoolQueueEdit(workPoolName, workPoolQueue.name)">
-      <p-overflow-menu-item v-if="can.update.work_pool_queue" label="Edit" />
+      <p-overflow-menu-item v-if="can.update.work_queue" label="Edit" />
     </router-link>
     <p-overflow-menu-item v-if="showDelete" label="Delete" @click="open" />
   </p-icon-button-menu>
@@ -49,7 +49,7 @@
   })
 
   const showDelete = computed(() => {
-    return !workPool.value || workPool.value.defaultQueueId !== props.workPoolQueue.id && can.delete.work_pool_queue
+    return !workPool.value || workPool.value.defaultQueueId !== props.workPoolQueue.id && can.delete.work_queue
   })
 
   async function deleteWorkPoolQueue(name: string): Promise<void> {

--- a/src/components/WorkPoolQueueToggle.vue
+++ b/src/components/WorkPoolQueueToggle.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-toggle v-if="can.update.work_pool_queue" v-model="internalValue" />
+  <p-toggle v-if="can.update.work_queue" v-model="internalValue" />
 </template>
 
 <script lang="ts" setup>

--- a/src/components/WorkPoolQueuesTable.vue
+++ b/src/components/WorkPoolQueuesTable.vue
@@ -7,7 +7,7 @@
             <ResultsCount v-if="selected.length == 0" label="Queue" :count="workPoolQueues.length" />
             <SelectedCount v-else :count="selected.length" />
 
-            <p-button v-if="can.create.work_pool_queue && !selected.length" inset size="sm" icon="PlusIcon" :to="routes.workPoolQueueCreate(workPoolName)" />
+            <p-button v-if="can.create.work_queue && !selected.length" inset size="sm" icon="PlusIcon" :to="routes.workPoolQueueCreate(workPoolName)" />
           </div>
 
           <WorkPoolQueuesDeleteButton :work-pool-name="workPoolName" :work-pool-queues="selected" @delete="handleDelete" />
@@ -85,7 +85,7 @@
     return workPoolQueuesData.value.filter(queue => hasString(queue, search.value))
   })
 
-  const selected = ref<WorkPoolQueue[] | undefined>(can.update.work_pool_queue ? [] : undefined)
+  const selected = ref<WorkPoolQueue[] | undefined>(can.update.work_queue ? [] : undefined)
   const columns = [
     {
       property: 'name',

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -297,7 +297,7 @@ export function createWorkspaceRouteRecords(components: Partial<WorkspaceRouteCo
               path: 'queue/:workPoolQueueName',
               component: components.workPoolQueue,
               meta: {
-                can: 'read:work_pool_queue',
+                can: 'read:work_queue',
               },
             },
             {
@@ -305,7 +305,7 @@ export function createWorkspaceRouteRecords(components: Partial<WorkspaceRouteCo
               path: 'queue/create',
               component: components.workPoolQueueCreate,
               meta: {
-                can: 'create:work_pool_queue',
+                can: 'create:work_queue',
               },
             },
             {
@@ -313,7 +313,7 @@ export function createWorkspaceRouteRecords(components: Partial<WorkspaceRouteCo
               path: 'queue/:workPoolQueueName/edit',
               component: components.workPoolQueueEdit,
               meta: {
-                can: 'update:work_pool_queue',
+                can: 'update:work_queue',
               },
             },
           ],


### PR DESCRIPTION
The work pool queue components and pages will use the same permissions that work queues currently use. This PR is a small update to use the existing work queue permission for work pool queue pages and components.

### Verification

Verified work pool queue creation, modification, and deletion with `nebula-ui` running against the staging API.