### PR TITLE
BugFix: Cannot create block that has a union property of multiple blocks

### DIFF
--- a/src/components/SchemaFormInput.vue
+++ b/src/components/SchemaFormInput.vue
@@ -41,7 +41,8 @@
 
   const isNullType = computed(() => props.property.type === 'null')
 
-  const { value: propValue, errorMessage, meta: state } = useField(props.propKey, meta.value?.validators)
+  const propKey = computed(() => props.property.type === 'block' ? `${props.propKey}.blockDocumentId` : props.propKey)
+  const { value: propValue, errorMessage, meta: state } = useField(propKey, meta.value?.validators)
 </script>
 
 <style>

--- a/src/components/SchemaPropertyKeyValue.vue
+++ b/src/components/SchemaPropertyKeyValue.vue
@@ -1,6 +1,6 @@
 <template>
-  <template v-if="isBlockDocumentProperty && typeof value === 'string'">
-    <BlockDocumentKeyValue :block-document-id="value" />
+  <template v-if="isBlockDocumentValue(value)">
+    <BlockDocumentKeyValue :block-document-id="value.blockDocumentId!" />
   </template>
   <!-- todo: support displaying nested objects -->
   <template v-else>
@@ -17,6 +17,7 @@
   import BlockDocumentKeyValue from '@/components/BlockDocumentKeyValue.vue'
   import CodeHighlighting from '@/components/CodeHighlighting.vue'
   import JsonInput from '@/components/JsonInput.vue'
+  import { isBlockDocumentValue } from '@/models'
   import { SchemaProperty, SchemaValue } from '@/types/schemas'
   import { stringifyUnknownJson } from '@/utilities/json'
 
@@ -30,7 +31,6 @@
   })
 
   const jsonValue = computed(() => stringifyUnknownJson(props.value) ?? undefined)
-  const isBlockDocumentProperty = computed(() => props.property.type === 'block')
 
   // todo: copied from PKeyValue. Hoping to update PKeyValue to eliminate the need for this
   const isDefined = computed((): boolean => {

--- a/src/models/api/BlockDocumentCreateRequest.ts
+++ b/src/models/api/BlockDocumentCreateRequest.ts
@@ -10,6 +10,15 @@ export function isBlockDocumentReferenceValue(value: SchemaValue): value is Bloc
   return typeof value === 'object' && value !== null && '$ref' in value
 }
 
+export type BlockDocumentValue = {
+  blockTypeSlug: string,
+  blockDocumentId: string | null,
+}
+
+export function isBlockDocumentValue(value: SchemaValue): value is BlockDocumentValue {
+  return typeof value === 'object' && value !== null && 'blockTypeSlug' in value && 'blockDocumentId' in value
+}
+
 export type BlockDocumentRequestData = Record<string, unknown | BlockDocumentReferenceValue>
 
 export type BlockDocumentCreateNamedRequest = {

--- a/src/services/schemas/properties/SchemaPropertyBlock.ts
+++ b/src/services/schemas/properties/SchemaPropertyBlock.ts
@@ -1,12 +1,15 @@
 import BlockDocumentInput from '@/components/BlockDocumentInput.vue'
-import { BlockDocumentReferenceValue, isBlockDocumentReferenceValue } from '@/models/api/BlockDocumentCreateRequest'
+import { BlockDocumentReferenceValue, BlockDocumentValue, isBlockDocumentValue } from '@/models/api/BlockDocumentCreateRequest'
 import { SchemaPropertyService } from '@/services/schemas/properties/SchemaPropertyService'
 import { SchemaPropertyComponentWithProps } from '@/services/schemas/utilities'
 import { SchemaValue } from '@/types/schemas'
 
 export class SchemaPropertyBlock extends SchemaPropertyService {
 
-  protected readonly default = null
+  protected readonly default: BlockDocumentValue = {
+    blockTypeSlug: this.property.blockTypeSlug!,
+    blockDocumentId: null,
+  }
 
   protected override get component(): SchemaPropertyComponentWithProps {
     return this.withProps(BlockDocumentInput, {
@@ -15,13 +18,13 @@ export class SchemaPropertyBlock extends SchemaPropertyService {
   }
 
   protected request(value: SchemaValue): unknown {
-    if (!value || typeof value !== 'string') {
+    if (!isBlockDocumentValue(value)) {
       return value
     }
 
     const request: BlockDocumentReferenceValue = {
       $ref: {
-        'block_document_id': value,
+        'block_document_id': value.blockDocumentId!,
       },
     }
 
@@ -29,8 +32,8 @@ export class SchemaPropertyBlock extends SchemaPropertyService {
   }
 
   protected response(value: SchemaValue): unknown {
-    if (isBlockDocumentReferenceValue(value)) {
-      return value.$ref.block_document_id
+    if (isBlockDocumentValue(value)) {
+      return value
     }
 
     this.invalid()

--- a/src/services/schemas/resolvers/blockReferences.ts
+++ b/src/services/schemas/resolvers/blockReferences.ts
@@ -1,4 +1,4 @@
-import { BlockDocumentReferencesResponse, BlockDocumentReferenceValue } from '@/models'
+import { BlockDocumentReferencesResponse, BlockDocumentValue } from '@/models'
 import { isSchemaValues, SchemaValues } from '@/types/schemas'
 import { mapEntries } from '@/utilities'
 
@@ -11,10 +11,9 @@ export function schemaValuesBlockReferencesResolver(values: SchemaValues, refere
     const reference = references[key]
 
     if (reference) {
-      const resolved: BlockDocumentReferenceValue = {
-        $ref: {
-          'block_document_id': reference.block_document.id,
-        },
+      const resolved: BlockDocumentValue = {
+        blockTypeSlug: reference.block_document.block_type.slug,
+        blockDocumentId: reference.block_document.id,
       }
 
       return resolved

--- a/src/services/schemas/utilities.ts
+++ b/src/services/schemas/utilities.ts
@@ -1,4 +1,5 @@
 import { JsonInput } from '@/components'
+import { isBlockDocumentValue } from '@/models'
 import { schemaPropertyServiceFactory } from '@/services/schemas/properties'
 import { SchemaProperty, SchemaPropertyInputAttrs, Schema, SchemaValues, SchemaValue, schemaHas, SchemaPropertyAnyOf } from '@/types/schemas'
 import { withPropsWithoutExcludedFactory } from '@/utilities/components'
@@ -202,6 +203,10 @@ export function getSchemaValueAnyOfDefinitionIndex({ anyOf: definitions }: Schem
 function findObjectDefinitionIndex(definitions: Schema[], value: object | null): number | null {
   if (value === null) {
     return null
+  }
+
+  if (isBlockDocumentValue(value)) {
+    return definitions.findIndex(definition => definition.blockTypeSlug === value.blockTypeSlug)
   }
 
   if (Array.isArray(value)) {

--- a/src/utilities/cache.ts
+++ b/src/utilities/cache.ts
@@ -1,5 +1,5 @@
 // this can be used to cache bust between releases. Incrementing this will remove all caches using the previous version
-const cacheVersion = 1
+const cacheVersion = 2
 const cachePrefix = 'cache-key'
 const cacheKeyPrefix = `${cachePrefix}-${cacheVersion}`
 


### PR DESCRIPTION
Fixes an issue with how references for blocks were being guessed based on the the value. Update the ui to always keep the block id and the block type slug together so anywhere in code we always know what type the block is. 

Before
![image](https://user-images.githubusercontent.com/6200442/214444173-8231485a-55cc-417c-9554-556eee6950cf.png)

After
<img width="1490" alt="image" src="https://user-images.githubusercontent.com/6200442/214444266-7d364cda-7c02-4cb4-951b-a7c40e60507b.png">


Close https://github.com/PrefectHQ/orion-design/issues/979