### PR TITLE
Enhancement: Add local timezone suggestion when unset and add groups to timezone select

### DIFF
--- a/src/components/TimezoneSelect.vue
+++ b/src/components/TimezoneSelect.vue
@@ -49,21 +49,23 @@
   onUnmounted(() => clearTimeout(timeout))
 
   const timezones = Intl.supportedValuesOf('timeZone').map(timezone => ({ label: timezone, value: timezone }))
-  const options: SelectOptionGroup[] = [
-    {
-      label: 'Suggested timezones',
-      options: [{ label: 'UTC', value: utcTimezone }],
-    },
-    {
-      label: 'All timezones',
-      options: [...timezones],
-    },
-  ]
+  const options = computed<SelectOptionGroup[]>(() => {
+    return [
+      {
+        label: 'Suggested timezones',
+        options: [{ label: 'UTC', value: utcTimezone }],
+      },
+      {
+        label: 'All timezones',
+        options: [...timezones],
+      },
+    ]
+  })
 
   const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
   if (!props.hideUnset) {
-    options[0].options.unshift({ label: 'Use browser default', value: null })
+    options.value[0].options.unshift({ label: 'Use browser default', value: null })
   } else {
-    options[0].options.unshift({ label: localTimezone, value: localTimezone })
+    options.value[0].options.unshift({ label: localTimezone, value: localTimezone })
   }
 </script>

--- a/src/components/TimezoneSelect.vue
+++ b/src/components/TimezoneSelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <p-combobox v-model="internalValue" :options="options" :append="timestamp">
+  <p-combobox v-model="internalValue" :options="timezoneOptions" :append="timestamp">
     <template v-for="(index, name) in $slots" #[name]="data">
       <slot :name="name" v-bind="data" />
     </template>
@@ -49,7 +49,7 @@
   onUnmounted(() => clearTimeout(timeout))
 
   const timezones = Intl.supportedValuesOf('timeZone').map(timezone => ({ label: timezone, value: timezone }))
-  const options = computed<SelectOptionGroup[]>(() => {
+  const timezoneOptions = computed<SelectOptionGroup[]>(() => {
     return [
       {
         label: 'Suggested timezones',
@@ -64,8 +64,8 @@
 
   const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
   if (!props.hideUnset) {
-    options.value[0].options.unshift({ label: 'Use browser default', value: null })
+    timezoneOptions.value[0].options.unshift({ label: 'Use browser default', value: null })
   } else {
-    options.value[0].options.unshift({ label: localTimezone, value: localTimezone })
+    timezoneOptions.value[0].options.unshift({ label: localTimezone, value: localTimezone })
   }
 </script>

--- a/src/components/TimezoneSelect.vue
+++ b/src/components/TimezoneSelect.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { SelectOption } from '@prefecthq/prefect-design'
+  import { SelectOptionGroup } from '@prefecthq/prefect-design'
   import { computed, onUnmounted, ref } from 'vue'
   import { secondsInMinute, millisecondsInSecond, millisecondsInMinute } from '@/utilities/dates'
   import { formatDateInTimezone, utcTimezone } from '@/utilities/timezone'
@@ -49,12 +49,21 @@
   onUnmounted(() => clearTimeout(timeout))
 
   const timezones = Intl.supportedValuesOf('timeZone').map(timezone => ({ label: timezone, value: timezone }))
-  const options: SelectOption[] = [
-    { label: 'UTC', value: utcTimezone },
-    ...timezones,
+  const options: SelectOptionGroup[] = [
+    {
+      label: 'Suggested timezones',
+      options: [{ label: 'UTC', value: utcTimezone }],
+    },
+    {
+      label: 'All timezones',
+      options: [...timezones],
+    },
   ]
 
+  const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
   if (!props.hideUnset) {
-    options.unshift({ label: 'Use browser default', value: null })
+    options[0].options.unshift({ label: 'Use browser default', value: null })
+  } else {
+    options[0].options.unshift({ label: localTimezone, value: localTimezone })
   }
 </script>

--- a/src/components/TimezoneSelect.vue
+++ b/src/components/TimezoneSelect.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { SelectOptionGroup } from '@prefecthq/prefect-design'
+  import { SelectOptionGroup, SelectOption } from '@prefecthq/prefect-design'
   import { computed, onUnmounted, ref } from 'vue'
   import { secondsInMinute, millisecondsInSecond, millisecondsInMinute } from '@/utilities/dates'
   import { formatDateInTimezone, utcTimezone } from '@/utilities/timezone'
@@ -48,24 +48,29 @@
 
   onUnmounted(() => clearTimeout(timeout))
 
+
   const timezones = Intl.supportedValuesOf('timeZone').map(timezone => ({ label: timezone, value: timezone }))
+  const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
   const timezoneOptions = computed<SelectOptionGroup[]>(() => {
+    const suggested: SelectOption[] = [
+      { label: localTimezone, value: localTimezone },
+      { label: 'UTC', value: utcTimezone },
+    ]
+
+    if (!props.hideUnset) {
+      suggested.unshift({ label: 'Use browser default', value: null })
+    }
+
     return [
       {
         label: 'Suggested timezones',
-        options: [{ label: 'UTC', value: utcTimezone }],
+        options: suggested,
       },
       {
         label: 'All timezones',
-        options: [...timezones],
+        options: timezones,
       },
     ]
   })
-
-  const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
-  if (!props.hideUnset) {
-    timezoneOptions.value[0].options.unshift({ label: 'Use browser default', value: null })
-  } else {
-    timezoneOptions.value[0].options.unshift({ label: localTimezone, value: localTimezone })
-  }
 </script>


### PR DESCRIPTION
Current: 
Need to know timezone string to set local timezone
<img width="586" alt="image" src="https://user-images.githubusercontent.com/40272060/214904900-2acd4fe2-09ae-4327-80e9-c7b82faa8a71.png">
New: 
Adds a suggested timezone group and all timezone group and adds localtimezone  as a string when unset is passed as a prop. 
<img width="567" alt="image" src="https://user-images.githubusercontent.com/40272060/214905111-30ce0041-2e9b-4022-9b46-72b807baf726.png">

Closes https://github.com/PrefectHQ/orion-design/issues/1062