### PR TITLE
Enhancement: Add a small message about collections to the blocks page

### DIFF
--- a/src/components/PageHeadingBlocksCatalog.vue
+++ b/src/components/PageHeadingBlocksCatalog.vue
@@ -1,11 +1,20 @@
 <template>
   <page-heading class="page-heading-blocks-catalog" :crumbs="crumbs" />
+  <p-message class="page-heading-blocks-catalog__message">
+    Below are all the block types currently registered.
+    If you don't see a block for the service you're using check out our
+    <p-link :to="localization.docs.collections">
+      collections catalog
+    </p-link>
+    to view a list of integrations and their corresponding blocks.
+  </p-message>
 </template>
 
 <script lang="ts" setup>
   import { BreadCrumbs } from '@prefecthq/prefect-design'
   import PageHeading from '@/components/PageHeading.vue'
   import { useWorkspaceRoutes } from '@/compositions'
+  import { localization } from '@/localization'
 
   const routes = useWorkspaceRoutes()
 
@@ -14,3 +23,10 @@
     { text: 'Choose a Block' },
   ]
 </script>
+
+<style>
+.page-heading-blocks-catalog__message {
+  @apply
+  pl-0
+}
+</style>

--- a/src/components/PageHeadingBlocksCatalog.vue
+++ b/src/components/PageHeadingBlocksCatalog.vue
@@ -1,7 +1,7 @@
 <template>
   <page-heading class="page-heading-blocks-catalog" :crumbs="crumbs" />
   <p-message class="page-heading-blocks-catalog__message">
-    If you don't see a block for the service you're using check out our
+    If you don't see a block for the service you're using, check out our
     <p-link :to="localization.docs.collections">
       Collections Catalog
     </p-link>

--- a/src/components/PageHeadingBlocksCatalog.vue
+++ b/src/components/PageHeadingBlocksCatalog.vue
@@ -4,7 +4,7 @@
     Below are all the block types currently registered.
     If you don't see a block for the service you're using check out our
     <p-link :to="localization.docs.collections">
-      collections catalog
+      Collections Catalog
     </p-link>
     to view a list of integrations and their corresponding blocks.
   </p-message>

--- a/src/components/PageHeadingBlocksCatalog.vue
+++ b/src/components/PageHeadingBlocksCatalog.vue
@@ -1,7 +1,6 @@
 <template>
   <page-heading class="page-heading-blocks-catalog" :crumbs="crumbs" />
   <p-message class="page-heading-blocks-catalog__message">
-    Below are all the block types currently registered.
     If you don't see a block for the service you're using check out our
     <p-link :to="localization.docs.collections">
       Collections Catalog

--- a/src/localization/locale/en.ts
+++ b/src/localization/locale/en.ts
@@ -10,6 +10,7 @@ export const en = {
     concurrency: 'https://docs.prefect.io/concepts/tasks/?h=conc#task-run-concurrency-limits',
     automations: 'https://docs.prefect.io/ui/automations/',
     workPools: 'https://docs.prefect.io/ui/work-pools/',
+    collections: 'https://orion-docs.prefect.io/collections/catalog/',
   },
   error: {
     activateDeployment: 'Failed to activate deployment',


### PR DESCRIPTION
Adds a link to the collections catalog docs on the blocks catalog page. 

Closes https://github.com/PrefectHQ/prefect/issues/8211
cc @ahuang11 

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/40272060/215263652-06f588e6-206f-489e-92f0-0bdbfd26189d.png">
