### PR TITLE
BugFix: line numbers when > 9 lines

### DIFF
--- a/src/components/CodeLines.vue
+++ b/src/components/CodeLines.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="code-lines" :class="classes">
+  <div class="code-lines" :class="classes.container">
     <!-- eslint-disable-next-line vue/no-v-html -->
     <pre class="code-lines__lines"><template v-for="(line, index) in lines" :key="index"><span class="code-lines__line" v-html="line" /></template></pre>
   </div>
@@ -7,6 +7,7 @@
 
 <script lang="ts" setup>
   import { computed } from 'vue'
+  import { countDigits } from '@/utilities'
 
   const props = defineProps<{
     code: string,
@@ -14,9 +15,12 @@
   }>()
 
   const lines = computed(() => props.code.split('\n'))
+  const lineNumbersWidth = computed(() => `${30 + countDigits(lines.value.length) * 2}px`)
 
   const classes = computed(() => ({
-    'code-lines--with-line-numbers': props.showLineNumbers,
+    container: {
+      'code-lines--with-line-numbers': props.showLineNumbers,
+    },
   }))
 </script>
 
@@ -33,12 +37,14 @@
 
 .code-lines--with-line-numbers .code-lines__line:before { @apply
   inline-block
-  px-3
+  pr-3
   mr-5
+  text-right
   border-r-[1px]
   border-slate-400
   text-slate-400;
   counter-increment: line;
   content: counter(line);
+  width: v-bind(lineNumbersWidth);
 }
 </style>

--- a/src/utilities/math.ts
+++ b/src/utilities/math.ts
@@ -16,6 +16,10 @@ const weightedNumber = (): number => {
   return choice(range(101, 1000))
 }
 
+export function countDigits(value: number): number {
+  return Math.max(Math.floor(Math.log10(Math.abs(value))), 0) + 1
+}
+
 export {
   uniform,
   coinflip,

--- a/src/utilities/math.ts
+++ b/src/utilities/math.ts
@@ -17,7 +17,7 @@ const weightedNumber = (): number => {
 }
 
 export function countDigits(value: number): number {
-  return Math.max(Math.floor(Math.log10(Math.abs(value))), 0) + 1
+  return `${value}`.length
 }
 
 export {


### PR DESCRIPTION
using v-bind to allocate sufficient space for each digit place in `lines.length`
tested up to 1000 lines, theoretically should work for any size

open to more elegant css solutions if you know of one

before:
<img width="993" alt="Screen Shot 2023-01-28 at 3 03 25 PM" src="https://user-images.githubusercontent.com/6098901/215291762-5356bae0-936c-4eeb-945c-0ecb29dc7f9f.png">

after:
<img width="1001" alt="Screen Shot 2023-01-28 at 3 20 13 PM" src="https://user-images.githubusercontent.com/6098901/215291765-dd29c61a-0386-4fb8-85c3-a25046380baa.png">
