### PR TITLE
bump graphs dependency to 0.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@prefecthq/orion-design",
             "version": "1.2.9",
             "dependencies": {
-                "@prefecthq/graphs": "0.1.13",
+                "@prefecthq/graphs": "0.1.14",
                 "@prefecthq/radar": "0.0.19",
                 "@prefecthq/vue-charts": "0.0.19",
                 "axios": "0.27.2",
@@ -937,9 +937,9 @@
             }
         },
         "node_modules/@prefecthq/graphs": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.13.tgz",
-            "integrity": "sha512-XnDBajUFKlLnujYiI1mv64NdHooFNmjO98XQnCM93ujLJAM7GTFBVGoZROvKlQJ5TlTmqvd0+fPeepvUvNzvLg==",
+            "version": "0.1.14",
+            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.14.tgz",
+            "integrity": "sha512-KVZi5qnl1ddXa+emfEYGPYoIgFYzq93tBFAS7ilO1yxcGnByrgEmhYM79jQZyKQJ+2wDFyhHmILnQsnFCS0gHg==",
             "dependencies": {
                 "@pixi-essentials/cull": "^1.1.0",
                 "@prefecthq/vue-compositions": "1.0.0",
@@ -6939,9 +6939,9 @@
             }
         },
         "@prefecthq/graphs": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.13.tgz",
-            "integrity": "sha512-XnDBajUFKlLnujYiI1mv64NdHooFNmjO98XQnCM93ujLJAM7GTFBVGoZROvKlQJ5TlTmqvd0+fPeepvUvNzvLg==",
+            "version": "0.1.14",
+            "resolved": "https://registry.npmjs.org/@prefecthq/graphs/-/graphs-0.1.14.tgz",
+            "integrity": "sha512-KVZi5qnl1ddXa+emfEYGPYoIgFYzq93tBFAS7ilO1yxcGnByrgEmhYM79jQZyKQJ+2wDFyhHmILnQsnFCS0gHg==",
             "requires": {
                 "@pixi-essentials/cull": "^1.1.0",
                 "@prefecthq/vue-compositions": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "vue-router": "^4.0.12"
     },
     "dependencies": {
-        "@prefecthq/graphs": "0.1.13",
+        "@prefecthq/graphs": "0.1.14",
         "@prefecthq/radar": "0.0.19",
         "@prefecthq/vue-charts": "0.0.19",
         "axios": "0.27.2",


### PR DESCRIPTION
This bumps the graphs dependency. The latest version fixes rendering in Safari and Firefox browsers.

I have tested locally latest graphs -> orion-design -> nebula and confirmed graphs rendered in Safari.