### PR TITLE
Chore: replaces CodeHighlighting with CodeSnippet

### DIFF
--- a/src/components/SchemaPropertyKeyValue.vue
+++ b/src/components/SchemaPropertyKeyValue.vue
@@ -6,7 +6,7 @@
   <template v-else>
     <p-key-value :label="property.title" :value="value" class="schema-property-key-value">
       <template v-if="isDefined && isJsonProperty" #value>
-        <CodeSnippet language="json" :snippet="jsonValue || ''" />
+        <CodeSnippet language="json" :snippet="jsonValue ?? ''" />
       </template>
     </p-key-value>
   </template>

--- a/src/components/SchemaPropertyKeyValue.vue
+++ b/src/components/SchemaPropertyKeyValue.vue
@@ -6,7 +6,7 @@
   <template v-else>
     <p-key-value :label="property.title" :value="value" class="schema-property-key-value">
       <template v-if="isDefined && isJsonProperty" #value>
-        <CodeHighlighting language="json" :value="jsonValue" />
+        <CodeSnippet language="json" :snippet="jsonValue || ''" />
       </template>
     </p-key-value>
   </template>
@@ -15,7 +15,7 @@
 <script lang="ts" setup>
   import { computed } from 'vue'
   import BlockDocumentKeyValue from '@/components/BlockDocumentKeyValue.vue'
-  import CodeHighlighting from '@/components/CodeHighlighting.vue'
+  import CodeSnippet from '@/components/CodeSnippet.vue'
   import JsonInput from '@/components/JsonInput.vue'
   import { isBlockDocumentValue } from '@/models'
   import { SchemaProperty, SchemaValue } from '@/types/schemas'


### PR DESCRIPTION
Fixes light-mode contrast issue in block values (specifically json) by switching `CodeHighlighting` component to `CodeSnippet`.

This file could use some clean up, what with the "todo" comments.

Before:
![Screen Shot 2023-02-01 at 11 51 05 PM](https://user-images.githubusercontent.com/11204953/216248921-6521afd7-7a65-440f-94e6-c84aaac5abd5.png)

After:
![Screen Shot 2023-02-02 at 12 23 41 AM](https://user-images.githubusercontent.com/11204953/216248933-d0762581-4dcb-44a9-b124-02a12ddfea4d.png)
