### PR TITLE
BugFix: Fix optional block references error

### DIFF
--- a/src/components/SchemaPropertyBlockKeyValue.vue
+++ b/src/components/SchemaPropertyBlockKeyValue.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="schema-property-block-key-value">
+    <PKeyValue class="block-document-key-value" :label="property.title">
+      <template v-if="blockDocument" #value>
+        <template v-if="blockDocument">
+          <p-link :to="routes.block(blockDocument.id)">
+            {{ blockDocument.name }}
+          </p-link>
+        </template>
+      </template>
+    </PKeyValue>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { PKeyValue, PLink } from '@prefecthq/prefect-design'
+  import { useSubscriptionWithDependencies } from '@prefecthq/vue-compositions'
+  import { computed } from 'vue'
+  import { useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
+  import { BlockDocumentValue } from '@/models/api/BlockDocumentCreateRequest'
+  import { SchemaProperty } from '@/types'
+
+  const props = defineProps<{
+    property: SchemaProperty,
+    value: BlockDocumentValue,
+  }>()
+
+  const api = useWorkspaceApi()
+  const routes = useWorkspaceRoutes()
+  const args = computed<[string] | null>(() => {
+    if (props.value.blockDocumentId) {
+      return [props.value.blockDocumentId]
+    }
+
+    return null
+  })
+  const subscription = useSubscriptionWithDependencies(api.blockDocuments.getBlockDocument, args)
+  const blockDocument = computed(() => subscription.response)
+</script>

--- a/src/components/SchemaPropertyKeyValue.vue
+++ b/src/components/SchemaPropertyKeyValue.vue
@@ -1,6 +1,6 @@
 <template>
   <template v-if="isBlockDocumentValue(value)">
-    <BlockDocumentKeyValue :block-document-id="value.blockDocumentId!" />
+    <SchemaPropertyBlockKeyValue v-bind="{ property, value }" />
   </template>
   <!-- todo: support displaying nested objects -->
   <template v-else>
@@ -14,9 +14,9 @@
 
 <script lang="ts" setup>
   import { computed } from 'vue'
-  import BlockDocumentKeyValue from '@/components/BlockDocumentKeyValue.vue'
   import CodeSnippet from '@/components/CodeSnippet.vue'
   import JsonInput from '@/components/JsonInput.vue'
+  import SchemaPropertyBlockKeyValue from '@/components/SchemaPropertyBlockKeyValue.vue'
   import { isBlockDocumentValue } from '@/models'
   import { SchemaProperty, SchemaValue } from '@/types/schemas'
   import { stringifyUnknownJson } from '@/utilities/json'

--- a/src/services/schemas/properties/SchemaPropertyBlock.ts
+++ b/src/services/schemas/properties/SchemaPropertyBlock.ts
@@ -22,6 +22,10 @@ export class SchemaPropertyBlock extends SchemaPropertyService {
       return value
     }
 
+    if (!value.blockDocumentId) {
+      return undefined
+    }
+
     const request: BlockDocumentReferenceValue = {
       $ref: {
         'block_document_id': value.blockDocumentId!,


### PR DESCRIPTION
# Description
When creating a block that has an optional block reference it will 500 if that block reference is empty. This is because the mapper was leaving the `null` value in the request when it should be removed from the request completely. 

Also fixes displaying block documents references when viewing a block in the ui. 
