### PR TITLE
BugFix: Block catalog collections message missing padding

### DIFF
--- a/src/components/PageHeadingBlocksCatalog.vue
+++ b/src/components/PageHeadingBlocksCatalog.vue
@@ -1,6 +1,7 @@
 <template>
   <page-heading class="page-heading-blocks-catalog" :crumbs="crumbs" />
-  <p-message class="page-heading-blocks-catalog__message">
+
+  <p-message>
     If you don't see a block for the service you're using, check out our
     <p-link :to="localization.docs.collections">
       Collections Catalog
@@ -22,10 +23,3 @@
     { text: 'Choose a Block' },
   ]
 </script>
-
-<style>
-.page-heading-blocks-catalog__message {
-  @apply
-  pl-0
-}
-</style>


### PR DESCRIPTION
# Description

Before
<img width="1259" alt="image" src="https://user-images.githubusercontent.com/6200442/216433345-0e996059-5af6-4599-8497-3b08da0153b2.png">
