### PR TITLE
Chore: Hide delete button for default workQueues

### DIFF
--- a/src/components/WorkPoolQueuesDeleteButton.vue
+++ b/src/components/WorkPoolQueuesDeleteButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <Transition name="work-pool-queuess-delete-button-transition">
+  <Transition name="work-pool-queues-delete-button-transition">
     <p-button v-if="workPoolQueues.length > 0" danger icon="TrashIcon" @click="open" />
   </Transition>
   <ConfirmDeleteModal

--- a/src/components/WorkPoolQueuesTable.vue
+++ b/src/components/WorkPoolQueuesTable.vue
@@ -89,7 +89,7 @@
     return workPoolQueuesData.value.filter(queue => hasString(queue, search.value))
   })
 
-  const selected = ref<WorkPoolQueue[] | undefined>(can.update.work_queue ? [] : undefined)
+  const selected = ref<WorkPoolQueue[] | undefined>(can.delete.work_queue ? [] : undefined)
   const columns = [
     {
       property: 'name',

--- a/src/components/WorkPoolQueuesTable.vue
+++ b/src/components/WorkPoolQueuesTable.vue
@@ -23,10 +23,6 @@
           <WorkPoolQueuePriorityLabel />
         </template>
 
-        <template #status="{ row }">
-          <WorkQueueStatusBadge :work-queue="row" />
-        </template>
-
         <template #actions-heading>
           <span />
         </template>
@@ -35,6 +31,10 @@
           <p-link :to="routes.workPoolQueue(workPoolName, row.name)">
             <span>{{ row.name }}</span>
           </p-link>
+        </template>
+
+        <template #status="{ row }">
+          <WorkQueueStatusBadge :work-queue="row" />
         </template>
 
         <template #actions="{ row }">

--- a/src/components/WorkQueueMenu.vue
+++ b/src/components/WorkQueueMenu.vue
@@ -26,6 +26,7 @@
 
 <script lang="ts" setup>
   import { PIconButtonMenu, POverflowMenuItem } from '@prefecthq/prefect-design'
+  import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
   import { RouterLink } from 'vue-router'
   import ConfirmDeleteModal from '@/components/ConfirmDeleteModal.vue'
@@ -37,7 +38,7 @@
   import { deleteItem } from '@/utilities'
 
   const props = defineProps<{
-    workQueue: WorkQueue & { disabled?: boolean },
+    workQueue: WorkQueue,
   }>()
 
   const emits = defineEmits<{
@@ -49,8 +50,15 @@
   const routes = useWorkspaceRoutes()
   const { showModal, open, close } = useShowModal()
 
+  const workPoolsSubscription = useSubscription(api.workPools.getWorkPools, [])
+  const workPools = computed(() => workPoolsSubscription.response ?? [])
+
+  const isDefaultQueue = computed(() => {
+    return workPools.value.some(workPool => workPool.defaultQueueId === props.workQueue.id)
+  })
+
   const showDelete = computed(() => {
-    return !props.workQueue.disabled && can.delete.work_queue
+    return !isDefaultQueue.value && can.delete.work_queue
   })
 
   const deleteWorkQueue = async (id: string): Promise<void> => {

--- a/src/components/WorkQueueMenu.vue
+++ b/src/components/WorkQueueMenu.vue
@@ -37,7 +37,7 @@
   import { deleteItem } from '@/utilities'
 
   const props = defineProps<{
-    workQueue: WorkQueue & { disabled: boolean },
+    workQueue: WorkQueue & { disabled?: boolean },
   }>()
 
   const emits = defineEmits<{

--- a/src/components/WorkQueueMenu.vue
+++ b/src/components/WorkQueueMenu.vue
@@ -5,7 +5,7 @@
       <p-overflow-menu-item label="Edit" />
     </router-link>
     <slot v-bind="{ workQueue }" />
-    <p-overflow-menu-item v-if="can.delete.work_queue" label="Delete" @click="open" />
+    <p-overflow-menu-item v-if="showDelete" label="Delete" @click="open" />
   </p-icon-button-menu>
 
   <ConfirmDeleteModal
@@ -26,6 +26,7 @@
 
 <script lang="ts" setup>
   import { PIconButtonMenu, POverflowMenuItem } from '@prefecthq/prefect-design'
+  import { computed } from 'vue'
   import { RouterLink } from 'vue-router'
   import ConfirmDeleteModal from '@/components/ConfirmDeleteModal.vue'
   import CopyOverflowMenuItem from '@/components/CopyOverflowMenuItem.vue'
@@ -35,8 +36,8 @@
   import { WorkQueue } from '@/models'
   import { deleteItem } from '@/utilities'
 
-  defineProps<{
-    workQueue: WorkQueue,
+  const props = defineProps<{
+    workQueue: WorkQueue & { disabled: boolean },
   }>()
 
   const emits = defineEmits<{
@@ -47,6 +48,10 @@
   const can = useCan()
   const routes = useWorkspaceRoutes()
   const { showModal, open, close } = useShowModal()
+
+  const showDelete = computed(() => {
+    return !props.workQueue.disabled && can.delete.work_queue
+  })
 
   const deleteWorkQueue = async (id: string): Promise<void> => {
     close()

--- a/src/components/WorkQueuesDeleteButton.vue
+++ b/src/components/WorkQueuesDeleteButton.vue
@@ -16,9 +16,10 @@
   import ConfirmDeleteModal from '@/components/ConfirmDeleteModal.vue'
   import { useShowModal, useWorkspaceApi } from '@/compositions'
   import { localization } from '@/localization'
+  import { WorkQueue } from '@/models'
 
   defineProps<{
-    selected: string[],
+    selected: WorkQueue[],
   }>()
 
   const emit = defineEmits<{
@@ -29,7 +30,7 @@
 
   const api = useWorkspaceApi()
 
-  const deleteWorkQueues = async (workQueues: string[]): Promise<void> => {
+  const deleteWorkQueues = async (workQueues: WorkQueue[]): Promise<void> => {
     const toastMessage = computed(() => {
       if (workQueues.length === 1) {
         return localization.success.delete('Work queue')
@@ -38,7 +39,7 @@
     })
 
     try {
-      const deleteWorkQueues = workQueues.map(api.workQueues.deleteWorkQueue)
+      const deleteWorkQueues = workQueues.map(queue => api.workQueues.deleteWorkQueue(queue.id))
       await Promise.all(deleteWorkQueues)
       showToast(toastMessage, 'success')
       emit('delete')

--- a/src/components/WorkQueuesTable.vue
+++ b/src/components/WorkQueuesTable.vue
@@ -65,7 +65,7 @@
 <script lang="ts" setup>
   import { PTable, PEmptyResults, PLink, TableData } from '@prefecthq/prefect-design'
   import { useSubscription } from '@prefecthq/vue-compositions'
-  import { computed, ref } from 'vue'
+  import { computed, ref, toRefs } from 'vue'
   import { WorkQueueToggle, WorkQueueLateIndicator, SearchInput, ResultsCount, WorkQueueLastPolled, WorkQueueStatusBadge, SelectedCount, WorkQueuesDeleteButton, WorkQueueMenu } from '@/components'
   import { useCan, useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { WorkQueue } from '@/models'
@@ -74,6 +74,8 @@
   const props = defineProps<{
     workQueues: WorkQueue[],
   }>()
+
+  const { workQueues } = toRefs(props)
 
   const emit = defineEmits<{
     (event: 'update' | 'delete'): void,
@@ -84,7 +86,7 @@
   const routes = useWorkspaceRoutes()
 
   const search = ref('')
-  const selected = ref<WorkQueue[] | undefined>(can.update.work_queue ? [] : undefined)
+  const selected = ref<WorkQueue[] | undefined>(can.delete.work_queue ? [] : undefined)
 
   const columns = [
     {
@@ -113,7 +115,7 @@
   const workPoolsSubscription = useSubscription(api.workPools.getWorkPools, [], subscriptionOptions)
   const workPools = computed(() => workPoolsSubscription.response ?? [])
 
-  const workQueuesData = computed<TableData[]>(() => props.workQueues.map(queue => {
+  const workQueuesData = computed<TableData[]>(() => workQueues.value.map(queue => {
     return {
       ...queue,
       disabled: workPools.value.some(pool => pool.defaultQueueId == queue.id),
@@ -130,7 +132,8 @@
 
   const handleDelete = (): void => {
     emit('delete')
-    selected.value = selected.value?.filter(queue => props.workQueues.find(({ id }) => id === queue.id))
+    selected.value = []
+    selected.value = selected.value.filter(queue => workQueues.value.find(({ id }) => id === queue.id))
   }
 
   function clear(): void {

--- a/src/components/WorkQueuesTable.vue
+++ b/src/components/WorkQueuesTable.vue
@@ -2,24 +2,23 @@
   <div class="work-queues-table">
     <p-layout-table>
       <template #header-start>
-        <ResultsCount v-if="selectedWorkQueues.length == 0" label="Work queue" :count="filteredWorkQueues.length" />
-        <SelectedCount v-else :count="selectedWorkQueues.length" />
+        <template v-if="selected">
+          <ResultsCount v-if="selected.length == 0" label="Work queue" :count="filteredWorkQueues.length" />
+          <SelectedCount v-else :count="selected.length" />
 
-        <WorkQueuesDeleteButton v-if="can.delete.work_queue" :selected="selectedWorkQueues" @delete="deleteWorkQueues" />
+          <WorkQueuesDeleteButton v-if="can.delete.work_queue" :selected="selected" @delete="handleDelete" />
+        </template>
       </template>
 
       <template #header-end>
-        <SearchInput v-model="searchTerm" placeholder="Search work queues" label="Search work queues" />
+        <SearchInput v-model="search" placeholder="Search work queues" label="Search work queues" />
       </template>
 
-      <p-table :data="filteredWorkQueues" :columns="columns">
-        <template #selection-heading>
-          <p-checkbox v-model="model" @update:model-value="selectAllWorkQueues" />
+      <p-table v-model:selected="selected" :data="filteredWorkQueues" :columns="columns">
+        <template #action-heading>
+          <span />
         </template>
 
-        <template #selection="{ row }">
-          <p-checkbox v-model="selectedWorkQueues" :value="row.id" />
-        </template>
         <template #name="{ row }">
           <p-link :to="routes.workQueue(row.id)">
             <span>{{ row.name }}</span>
@@ -38,15 +37,11 @@
           <WorkQueueLastPolled :work-queue-id="row.id" />
         </template>
 
-        <template #action-heading>
-          <span />
-        </template>
-
         <template #action="{ row }">
           <div class="work-queues-table__actions">
             <WorkQueueLateIndicator :work-queue-id="row.id" />
             <WorkQueueToggle :work-queue="row" @update="emit('update')" />
-            <WorkQueueMenu size="xs" :work-queue="row" @delete="emit('delete')" />
+            <WorkQueueMenu size="xs" :work-queue="row" @delete="handleDelete" />
           </div>
         </template>
 
@@ -68,11 +63,13 @@
 </template>
 
 <script lang="ts" setup>
-  import { PTable, PEmptyResults, PLink, CheckboxModel } from '@prefecthq/prefect-design'
+  import { PTable, PEmptyResults, PLink, TableData } from '@prefecthq/prefect-design'
+  import { useSubscription } from '@prefecthq/vue-compositions'
   import { computed, ref } from 'vue'
-  import { WorkQueueToggle, WorkQueueLateIndicator, SearchInput, ResultsCount, WorkQueueLastPolled, WorkQueueStatusBadge, SelectedCount, WorkQueuesDeleteButton } from '@/components'
-  import { useCan, useComponent, useWorkspaceRoutes } from '@/compositions'
+  import { WorkQueueToggle, WorkQueueLateIndicator, SearchInput, ResultsCount, WorkQueueLastPolled, WorkQueueStatusBadge, SelectedCount, WorkQueuesDeleteButton, WorkQueueMenu } from '@/components'
+  import { useCan, useWorkspaceApi, useWorkspaceRoutes } from '@/compositions'
   import { WorkQueue } from '@/models'
+  import { hasString } from '@/utilities'
 
   const props = defineProps<{
     workQueues: WorkQueue[],
@@ -82,17 +79,14 @@
     (event: 'update' | 'delete'): void,
   }>()
 
-  const { WorkQueueMenu } = useComponent()
+  const api = useWorkspaceApi()
   const can = useCan()
   const routes = useWorkspaceRoutes()
-  const searchTerm = ref('')
+
+  const search = ref('')
+  const selected = ref<WorkQueue[] | undefined>(can.update.work_queue ? [] : undefined)
 
   const columns = [
-    {
-      label: 'selection',
-      width: '20px',
-      visible: can.delete.work_queue,
-    },
     {
       property: 'name',
       label: 'Name',
@@ -112,41 +106,35 @@
     },
   ]
 
-  const selectedWorkQueues = ref<string[]>([])
-  const selectAllWorkQueues = (allWorkQueuesSelected: CheckboxModel): string[] => {
-    if (allWorkQueuesSelected) {
-      return selectedWorkQueues.value = [...filteredWorkQueues.value.map(workQueue => workQueue.id)]
-    }
-    return selectedWorkQueues.value = []
+  const subscriptionOptions = {
+    interval: 30000,
   }
-  const model = computed({
-    get() {
-      return selectedWorkQueues.value.length === filteredWorkQueues.value.length
-    },
-    set(value: boolean) {
-      selectAllWorkQueues(value)
-    },
-  })
+
+  const workPoolsSubscription = useSubscription(api.workPools.getWorkPools, [], subscriptionOptions)
+  const workPools = computed(() => workPoolsSubscription.response ?? [])
+
+  const workQueuesData = computed<TableData[]>(() => props.workQueues.map(queue => {
+    return {
+      ...queue,
+      disabled: workPools.value.some(pool => pool.defaultQueueId == queue.id),
+    }
+  }))
 
   const filteredWorkQueues = computed(() => {
-    if (searchTerm.value.length === 0) {
-      return props.workQueues
+    if (search.value.length === 0) {
+      return workQueuesData.value
     }
 
-    return props.workQueues.filter(filterWorkQueue)
+    return workQueuesData.value.filter(queue => hasString(queue, search.value))
   })
 
-  function filterWorkQueue({ name, concurrencyLimit }: WorkQueue): boolean {
-    return `${name} ${concurrencyLimit}`.toLowerCase().includes(searchTerm.value.toLowerCase())
+  const handleDelete = (): void => {
+    emit('delete')
+    selected.value = selected.value?.filter(queue => props.workQueues.find(({ id }) => id === queue.id))
   }
 
   function clear(): void {
-    searchTerm.value = ''
-  }
-
-  const deleteWorkQueues = (): void => {
-    selectedWorkQueues.value = []
-    emit('delete')
+    search.value = ''
   }
 </script>
 


### PR DESCRIPTION
Since all work queues are now part of work pools on the backend, users who still use the work queues page encountered an issue where they tried to delete `default` work queues on that page and can't do that. The reason behind it is that the default queue cannot be deleted. Even though the work queues page will soon be deprecated, this PR fixes the issue for immediate users. The work queues table was rewritten in the same way as the work pool queues table, where default queues cannot be selected for multi-delete and do not have the option to delete them in the menu.