### PR TITLE
Chore: Add an optional prop to hide mini-radar

### DIFF
--- a/src/components/FlowRunDetails.vue
+++ b/src/components/FlowRunDetails.vue
@@ -57,7 +57,7 @@
 
     <p-divider />
 
-    <router-link :to="routes.flowRunRadar(flowRun.id)" class="flow-run-details__small-radar-link">
+    <router-link v-if="!hideRadar" :to="routes.flowRunRadar(flowRun.id)" class="flow-run-details__small-radar-link">
       <RadarSmall :flow-run-id="flowRun.id" class="flow-run-details__small-radar" />
     </router-link>
 
@@ -109,6 +109,7 @@
   const props = defineProps<{
     flowRun: FlowRun,
     alternate?: boolean,
+    hideRadar?: boolean,
   }>()
 
   const can = useCan()


### PR DESCRIPTION
Adds an optional hide-radar prop to enable hiding the mini-graph radar for accounts with super large flows. (Should only be temporary and for specific accounts. Currently not an open option.) 