### PR TITLE
Fix: fix deploymentFlowRunCreate route showing undefined query param

### DIFF
--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -20,7 +20,10 @@ export function createWorkspaceRoutes(config?: CreateWorkspaceRoutesConfig) {
     deployments: () => ({ name: 'workspace.deployments', params: { ...config } }) as const,
     deployment: (deploymentId: string) => ({ name: 'workspace.deployments.deployment', params: { deploymentId, ...config } }) as const,
     deploymentEdit: (deploymentId: string) => ({ name: 'workspace.deployments.deployment-edit', params: { deploymentId, ...config } }) as const,
-    deploymentFlowRunCreate: (deploymentId: string, parameters?: Record<string, unknown>) => ({ name: 'workspace.deployments.deployment-flow-run-create', params: { deploymentId, ...config }, query: { parameters: encodeURIComponent(JSON.stringify(parameters)) } }) as const,
+    deploymentFlowRunCreate: (deploymentId: string, parameters?: Record<string, unknown>) => {
+      const query = parameters ? { parameters: encodeURIComponent(JSON.stringify(parameters)) } : {}
+      return { name: 'workspace.deployments.deployment-flow-run-create', params: { deploymentId, ...config }, query } as const
+    },
     workQueues: () => ({ name: 'workspace.work-queues', params: { ...config } }) as const,
     workQueue: (workQueueId: string) => ({ name: 'workspace.work-queues.work-queue', params: { workQueueId, ...config } }) as const,
     workQueueCreate: () => ({ name: 'workspace.work-queues.work-queue-create', params: { ...config } }) as const,


### PR DESCRIPTION
This PR adds a fix to deploymentFlowRunCreate route to hide query param if there's no param provided

<img width="1624" alt="Screenshot 2023-02-07 at 3 33 32 PM" src="https://user-images.githubusercontent.com/40467112/217360246-509e0759-8996-4913-a87e-2082ad80a139.png">
