### PR TITLE
Add paused to cancellable states

### DIFF
--- a/src/models/StateType.ts
+++ b/src/models/StateType.ts
@@ -30,7 +30,7 @@ export function isTerminalStateType(value: string): value is TerminalStateType {
   return terminalStateType.includes(value as TerminalStateType)
 }
 
-export const stuckStateTypes = ['running', 'scheduled', 'pending']
+export const stuckStateTypes = ['running', 'scheduled', 'pending', 'paused']
 export type StuckStateType = typeof stuckStateTypes[number]
 export function isStuckStateType(value: string): value is StuckStateType {
   return stuckStateTypes.includes(value as StuckStateType)


### PR DESCRIPTION
- Adds `Paused` to the list of cancellable states.  
- Confirmed that this work with no further changes
- some codebase design feedback: calling these states `stuckStateTypes` with the state type models is confusing; "stuck" needs additional context to be a meaningful name.  Maybe something like `cancellableStateTypes` or `nonTerminalStateTypes` that doesn't require explanation

Closes https://github.com/PrefectHQ/prefect/issues/7807