### PR TITLE
Removes experimental prefix from work_pools routes

### DIFF
--- a/src/services/WorkspaceWorkPoolQueuesApi.ts
+++ b/src/services/WorkspaceWorkPoolQueuesApi.ts
@@ -14,7 +14,7 @@ export interface IWorkspaceWorkPoolQueuesApi {
 
 export class WorkspaceWorkPoolQueuesApi extends WorkspaceApi implements IWorkspaceWorkPoolQueuesApi {
 
-  protected override routePrefix = '/experimental/work_pools/'
+  protected override routePrefix = '/work_pools/'
 
   public async createWorkPoolQueue(workPoolName: string, request: WorkPoolQueueCreate): Promise<WorkPoolQueue> {
     const body = mapper.map('WorkPoolQueueCreate', request, 'WorkPoolQueueCreateRequest')

--- a/src/services/WorkspaceWorkPoolWorkersApi.ts
+++ b/src/services/WorkspaceWorkPoolWorkersApi.ts
@@ -7,7 +7,7 @@ export interface IWorkspaceWorkPoolWorkersApi {
 }
 
 export class WorkspaceWorkPoolWorkersApi extends WorkspaceApi implements IWorkspaceWorkPoolWorkersApi {
-  protected override routePrefix = '/experimental/work_pools/'
+  protected override routePrefix = '/work_pools/'
 
   public async getWorkers(workPoolName: string, filter: WorkPoolWorkerFilter = {}): Promise<WorkPoolWorker[]> {
     const { data } = await this.post<WorkPoolWorkerResponse[]>(`/${workPoolName}/workers/filter`, filter)

--- a/src/services/WorkspaceWorkPoolsApi.ts
+++ b/src/services/WorkspaceWorkPoolsApi.ts
@@ -16,7 +16,7 @@ export interface IWorkspaceWorkPoolsApi {
 
 export class WorkspaceWorkPoolsApi extends WorkspaceApi implements IWorkspaceWorkPoolsApi {
 
-  protected override routePrefix = '/experimental/work_pools/'
+  protected override routePrefix = '/work_pools/'
 
   public async createWorkPool(request: WorkPoolCreate): Promise<WorkPool> {
     const body = mapper.map('WorkPoolCreate', request, 'WorkPoolCreateRequest')


### PR DESCRIPTION
Removes /experimental prefix from work_pools routes in anticipation of work pools GA release.