### PR TITLE
Chore:  Add task input info to localization

### DIFF
--- a/src/localization/locale/en.ts
+++ b/src/localization/locale/en.ts
@@ -88,6 +88,6 @@ export const en = {
   info: {
     deprecatedWorkQueue: 'This work queue uses a deprecated tag-based approach to matching flow runs; it will continue to work but you can\'t modify it',
     deploymentMissingWorkQueue: 'This deployment doesn\'t have an associated work queue; runs will be scheduled but won\'t be picked up by your agents',
-    taskInput: 'Task inputs show parameter keys and task run relationships as part of results from other task runs.',
+    taskInput: 'Currently task inputs show parameter keys. The can also show task run relationships.',
   },
 }

--- a/src/localization/locale/en.ts
+++ b/src/localization/locale/en.ts
@@ -88,5 +88,6 @@ export const en = {
   info: {
     deprecatedWorkQueue: 'This work queue uses a deprecated tag-based approach to matching flow runs; it will continue to work but you can\'t modify it',
     deploymentMissingWorkQueue: 'This deployment doesn\'t have an associated work queue; runs will be scheduled but won\'t be picked up by your agents',
+    taskInput: 'Task inputs show parameter keys and task run relationships as part of results from other task runs.',
   },
 }


### PR DESCRIPTION
Adds task input description to localization rather than writing direct into OSS and Cloud.  This allows us to update in one place only and keep things in sync. 