### PR TITLE
Fix: Update queue result count for WorkPoolQueue table

### DIFF
--- a/src/components/WorkPoolQueuesTable.vue
+++ b/src/components/WorkPoolQueuesTable.vue
@@ -4,7 +4,7 @@
       <template #header-start>
         <template v-if="selected">
           <div class="work-pool-queues-table__controls--right">
-            <ResultsCount v-if="selected.length == 0" label="Work Queue" :count="workPoolQueues.length" />
+            <ResultsCount v-if="selected.length == 0" label="Work Queue" :count="filteredWorkPoolQueues.length" />
             <SelectedCount v-else :count="selected.length" />
 
             <p-button v-if="can.create.work_queue && !selected.length" inset size="sm" icon="PlusIcon" :to="routes.workPoolQueueCreate(workPoolName)" />


### PR DESCRIPTION
This PR updates `ResultCount` to show the correct number when filtered by name search for WorkPoolQueue table